### PR TITLE
TQ42-1360 fix notebooks to display on GitHub

### DIFF
--- a/notebooks/basic_example.ipynb
+++ b/notebooks/basic_example.ipynb
@@ -16,7 +16,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 30,
+   "execution_count": null,
    "id": "b3f3436a",
    "metadata": {
     "ExecuteTime": {
@@ -45,7 +45,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 32,
+   "execution_count": null,
    "id": "c87c20d3",
    "metadata": {
     "ExecuteTime": {
@@ -53,15 +53,7 @@
      "start_time": "2023-12-22T15:23:28.573754Z"
     }
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "[<tq42.organization.Organization object at 0x1064b77c0>]\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "with TQ42Client() as client: \n",
     "    org_list = list_all_organizations(client=client)\n",
@@ -79,7 +71,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 34,
+   "execution_count": null,
    "id": "1470d03e",
    "metadata": {
     "ExecuteTime": {
@@ -87,15 +79,7 @@
      "start_time": "2023-12-22T15:23:28.658251Z"
     }
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "[<tq42.project.Project object at 0x106473520>]\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "    proj_list = list_all_projects(client=client, organization_id=org.id)\n",
     "    proj = proj_list[0]\n",
@@ -112,24 +96,16 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 36,
+   "execution_count": null,
    "id": "c0dea937",
    "metadata": {
-    "scrolled": true,
     "ExecuteTime": {
      "end_time": "2023-12-22T15:23:29.211697Z",
      "start_time": "2023-12-22T15:23:28.753934Z"
-    }
+    },
+    "scrolled": true
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "[<tq42.experiment.Experiment object at 0x105b5b8b0>, <tq42.experiment.Experiment object at 0x105e31dc0>, <tq42.experiment.Experiment object at 0x106495820>, <tq42.experiment.Experiment object at 0x1064954c0>]\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "    exp_list = list_all_experiments(client=client, project_id=proj.id)\n",
     "    exp_sample = exp_list[-1]\n",
@@ -148,48 +124,31 @@
   },
   {
    "cell_type": "code",
+   "execution_count": null,
+   "id": "af745a754790a3de",
+   "metadata": {
+    "collapsed": false,
+    "jupyter": {
+     "outputs_hidden": false
+    }
+   },
    "outputs": [],
    "source": [
     "    print(f\"Running experiment within: Org {org.id}, Proj {proj.id} and Exp {exp_sample.id}`\")"
-   ],
-   "metadata": {
-    "collapsed": false
-   },
-   "id": "af745a754790a3de"
+   ]
   },
   {
    "cell_type": "code",
-   "execution_count": 39,
+   "execution_count": null,
    "id": "0611ddd6",
    "metadata": {
-    "scrolled": true,
     "ExecuteTime": {
      "end_time": "2023-12-22T15:23:29.675241Z",
      "start_time": "2023-12-22T15:23:29.468233Z"
-    }
+    },
+    "scrolled": true
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "id: \"3b09e70d-e6a7-44a4-8f85-07f310928ee2\"\n",
-      "experiment_id: \"796e95e6-a6bc-4880-92f9-13755a0772cd\"\n",
-      "sequential_id: 21\n",
-      "status: QUEUED\n",
-      "algorithm: TOY\n",
-      "hardware: SMALL\n",
-      "metadata: \"{\\\"parameters\\\":{\\\"n\\\":3,\\\"r\\\":1.5,\\\"msg\\\":\\\"hi!\\\"}}\"\n",
-      "result {\n",
-      "}\n",
-      "created_by: \"3011b225-73a6-470c-b2e1-6f3c3e358149\"\n",
-      "created_at {\n",
-      "  seconds: 1703258609\n",
-      "  nanos: 670783592\n",
-      "}\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "    parameters = {\n",
     "        \"parameters\": {\n",
@@ -220,24 +179,16 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 40,
+   "execution_count": null,
    "id": "235e707b",
    "metadata": {
-    "scrolled": true,
     "ExecuteTime": {
      "end_time": "2023-12-22T15:24:29.241912Z",
      "start_time": "2023-12-22T15:23:29.671856Z"
-    }
+    },
+    "scrolled": true
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "<tq42.experiment_run.ExperimentRun object at 0x10647c190>\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "    result = run.poll()\n",
     "    print(result)"
@@ -260,7 +211,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.5"
+   "version": "3.11.6"
   },
   "vscode": {
    "interpreter": {

--- a/notebooks/cva_opt_example.ipynb
+++ b/notebooks/cva_opt_example.ipynb
@@ -15,7 +15,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": null,
    "id": "dcd8d3ef-3069-4489-8397-8cba3b3ee769",
    "metadata": {},
    "outputs": [],
@@ -42,6 +42,14 @@
   },
   {
    "cell_type": "code",
+   "execution_count": null,
+   "id": "8c4d62de633fd4c1",
+   "metadata": {
+    "collapsed": false,
+    "jupyter": {
+     "outputs_hidden": false
+    }
+   },
    "outputs": [],
    "source": [
     "tq42client = TQ42Client()\n",
@@ -49,15 +57,11 @@
     "project_list = list_all_projects(client=tq42client, organization_id=org_list[0].id)\n",
     "experiment_list = list_all_experiments(client=tq42client, project_id=project_list[1].id)\n",
     "experiment_id = experiment_list[0].id"
-   ],
-   "metadata": {
-    "collapsed": false
-   },
-   "id": "8c4d62de633fd4c1"
+   ]
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": null,
    "id": "5bbbd0d2-4863-459b-a25f-bf4424fc94d3",
    "metadata": {},
    "outputs": [],
@@ -82,7 +86,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": null,
    "id": "01045aae-584a-4c7f-99b4-71897224cebc",
    "metadata": {},
    "outputs": [],
@@ -116,7 +120,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": null,
    "id": "c91a995b-083e-4049-bf9d-4f75cc742879",
    "metadata": {},
    "outputs": [],
@@ -136,7 +140,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": null,
    "id": "6575a6eb-9f6b-4f29-aeba-52e05cadb0d3",
    "metadata": {},
    "outputs": [],
@@ -156,7 +160,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": null,
    "id": "4951ca40-dc5c-4b1a-a684-55a1d958f704",
    "metadata": {},
    "outputs": [],
@@ -177,7 +181,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": null,
    "id": "823d4035-85fc-47ac-99ee-ffdc1ac7fb9f",
    "metadata": {},
    "outputs": [],
@@ -195,7 +199,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": null,
    "id": "a692af2c-cc48-45b9-9900-6f20a28795da",
    "metadata": {},
    "outputs": [],
@@ -227,7 +231,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": null,
    "id": "31e66e09-6761-48d1-8580-f4425324a1cd",
    "metadata": {},
    "outputs": [],
@@ -251,18 +255,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": null,
    "id": "284e6adb-2b77-455e-9c1a-8dff420a403d",
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "status: COMPLETED\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "run_result = run.poll()\n",
     "print('status: ' + ExperimentRunStatusProto.Name(run_result.data.status))"
@@ -278,57 +274,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": null,
    "id": "4bd7e1b3-40a0-4aa9-a571-3417d456cace",
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/html": [
-       "<div>\n",
-       "<style scoped>\n",
-       "    .dataframe tbody tr th:only-of-type {\n",
-       "        vertical-align: middle;\n",
-       "    }\n",
-       "\n",
-       "    .dataframe tbody tr th {\n",
-       "        vertical-align: top;\n",
-       "    }\n",
-       "\n",
-       "    .dataframe thead th {\n",
-       "        text-align: right;\n",
-       "    }\n",
-       "</style>\n",
-       "<table border=\"1\" class=\"dataframe\">\n",
-       "  <thead>\n",
-       "    <tr style=\"text-align: right;\">\n",
-       "      <th></th>\n",
-       "      <th>x1</th>\n",
-       "      <th>x2</th>\n",
-       "      <th>Sphere</th>\n",
-       "    </tr>\n",
-       "  </thead>\n",
-       "  <tbody>\n",
-       "    <tr>\n",
-       "      <th>0</th>\n",
-       "      <td>5.144655e-08</td>\n",
-       "      <td>2.814545e-08</td>\n",
-       "      <td>3.438914e-15</td>\n",
-       "    </tr>\n",
-       "  </tbody>\n",
-       "</table>\n",
-       "</div>"
-      ],
-      "text/plain": [
-       "             x1            x2        Sphere\n",
-       "0  5.144655e-08  2.814545e-08  3.438914e-15"
-      ]
-     },
-     "execution_count": 15,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "result_df = pandas.DataFrame(json.loads(getattr(getattr(run_result.data, 'result'), 'result_json'))['logs']['result'])\n",
     "result_df"
@@ -344,7 +293,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 57,
+   "execution_count": null,
    "id": "ac4f8761-3be1-4d12-9013-e53fd3b8baa5",
    "metadata": {},
    "outputs": [],
@@ -362,7 +311,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 58,
+   "execution_count": null,
    "id": "157db67b-73f6-4e39-b580-8810822629ab",
    "metadata": {},
    "outputs": [],
@@ -382,7 +331,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 59,
+   "execution_count": null,
    "id": "7829cc38-7ff4-4ae4-9c94-88621a154589",
    "metadata": {},
    "outputs": [],
@@ -402,7 +351,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 60,
+   "execution_count": null,
    "id": "97de8d12-3719-4756-aac2-151c874870b1",
    "metadata": {},
    "outputs": [],
@@ -421,7 +370,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 61,
+   "execution_count": null,
    "id": "c84dfcc9-5d6e-4268-b980-dccbfe6570f3",
    "metadata": {},
    "outputs": [],
@@ -439,7 +388,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 62,
+   "execution_count": null,
    "id": "79c33188-a105-4589-a61e-0675ee35dd1d",
    "metadata": {},
    "outputs": [],
@@ -463,18 +412,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 63,
+   "execution_count": null,
    "id": "a93e912a-5a6b-4855-a3f2-3c1c7f327e59",
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "status: COMPLETED\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "run_result = run.poll()\n",
     "print('status: ' + ExperimentRunStatusProto.Name(run_result.data.status))"
@@ -490,31 +431,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 64,
+   "execution_count": null,
    "id": "3ee55c78-21ef-4a35-9973-9c23436f7490",
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "<Axes: xlabel='ZDT1_1', ylabel='ZDT1_2'>"
-      ]
-     },
-     "execution_count": 64,
-     "metadata": {},
-     "output_type": "execute_result"
-    },
-    {
-     "data": {
-      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAjcAAAGwCAYAAABVdURTAAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjguMSwgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy/SrBM8AAAACXBIWXMAAA9hAAAPYQGoP6dpAABDI0lEQVR4nO3deXxU9b3/8fckJIEBMglJWIIhi0StsgWEyCoodS1qF6ugDXLBhSJqKT8Vq1C1FWuxpUUqV0GFq4BicbniRS0mIouELQKKGMjCmpCELCSRAMn5/UEzZUgymUlmz+v5eMzjmnO+58xnzoPOvO8538VkGIYhAACAABHk7QIAAABciXADAAACCuEGAAAEFMINAAAIKIQbAAAQUAg3AAAgoBBuAABAQGnn7QI8ra6uTkePHlXnzp1lMpm8XQ4AAHCAYRg6efKkYmNjFRRk/95Mmws3R48eVVxcnLfLAAAALXDo0CFddNFFdtu0uXDTuXNnSecuTnh4uJerAQAAjqioqFBcXJz1d9yeNhdu6h9FhYeHE24AAPAzjnQpoUMxAAAIKIQbAAAQUAg3AAAgoBBuAABAQCHcAACAgEK4AQAAAYVwAwAAAgrhBgAABBTCDQAACCiEGwAAEFDa3PIL7vTFvuPKOlymgb0iNTI5xtvlAADQJhFuXCC/pEq3Ldyo0uoz1m2R5hB9OG2E4qLMXqwMAIC2h8dSLnBhsJGk0uozumXhBi9VBABA20W4aaUv9h1vEGzqlVaf0ZfZRR6uCACAto1w00pZh8vs7t9xsNQzhQAAAEmEm1YbcFGE3f0De0V6phAAACCJcNNqV1/aVZHmkEb3RZpDGDUFAICHEW5c4MNpIxoEnPrRUgAAwLMYCu4CcVFm7Zx9nb7MLtKOg6XMcwMAgBcRblxoZHIMoQYAAC/jsRQAAAgohBsAABBQCDcAACCgEG4AAEBAIdwAAICAQrgBAAABhXADAAACCuEGAAAEFMINAAAIKIQbAAAQUAg3AAAgoBBuAABAQPFquFm/fr3GjRun2NhYmUwmvf/++3bbr169Wj/+8Y8VExOj8PBwDR06VJ988olnigUAAH7Bq+GmqqpK/fv318KFCx1qv379ev34xz/Wxx9/rO3bt2vMmDEaN26cdu7c6eZKAQCAvzAZhmF4uwhJMplMeu+993Tbbbc5ddwVV1yhO+64Q7Nnz3aofUVFhSwWi8rLyxUeHt6CSgEAgKc58/vdzkM1uUVdXZ1OnjypLl26NNmmpqZGNTU11r8rKio8URoAAPASv+5QPG/ePFVWVuqXv/xlk23mzp0ri8VifcXFxXmwQgAA4Gl+G26WL1+up59+Wu+88466du3aZLtZs2apvLzc+jp06JAHqwQAAJ7ml4+lVq5cqSlTpmjVqlUaO3as3bZhYWEKCwvzUGUAAMDb/O7OzYoVKzRp0iStWLFCN998s7fLAQAAPsard24qKyu1f/9+69+5ubnKyspSly5d1KtXL82aNUtHjhzRsmXLJJ17FDVx4kT97W9/U2pqqgoKCiRJHTp0kMVi8cpnAAAAvsWrd262bdumlJQUpaSkSJJmzJihlJQU67DuY8eO6eDBg9b2r7zyis6ePatp06apR48e1tfDDz/slfoBAIDv8Zl5bjyFeW4AAPA/zvx++12fGwAAAHsINwAAIKAQbgAAQEAh3AAAgIBCuAEAAAGFcAMAAAIK4QYAAAQUwg0AAAgohBsAABBQ/HJVcF/1xb7jyjpcpoG9IjUyOcbb5QAA0CYRblwgv6RKty3cqNLqM9ZtkeYQfThthOKizF6sDACAtofHUi5w60u2wUaSSqvPaNxLG7xUEQAAbRfhppW+2HdcZT+caXRf2Q9n9GV2kYcrAgCgbSPctFL6vuN293++1/5+AADgWoSbVurSMcz+/k6hHqoEAABIhJtW+0m/Hs3sj/VQJQAAQCLctFpSTCcNjo9sdN/g+EglRnf0cEUAALRthBsXmDPuCrULMtlsaxdk0tO3XOGligAAaLsINy5w95ItOltn2Gw7W2dowuItXqoIAIC2i3DTSgwFBwDAtxBuWomh4AAA+BbCTSsxFBwAAN9CuGklhoIDAOBbCDdudvJU4/1xAACAexBuWin/RLXd/U+8t9tDlQAAAIlw02rxXcx29+85UqHc4ioPVQMAAAg3rZQU00l9YsPttskrIdwAAOAphBsX+PWY3nb3Xzh7MQAAcB/CjQt0CA22u7+8iUn+AACA6xFuXKC5fjdLvsz1UCUAAIBw4wE7D5XRqRgAAA8h3LhAc8PBJWlLTokHKgEAAIQbF2jusZQkGc22AAAArkC4cYGkmE4anBBpt81VSVEeqgYAgLaNcOMii9MGK7iJEd+WDu2UGN3RswUBANBGEW5cpKSqRrVNPHsq/+EsHYoBAPAQwo2LNNepOOO7Qg9VAgBA2+bVcLN+/XqNGzdOsbGxMplMev/99+22P3bsmCZMmKBLLrlEQUFBeuSRRzxSpyOa61T89Ed7NeHVr1RezYR+AAC4k1fDTVVVlfr376+FCxc61L6mpkYxMTF68skn1b9/fzdX5xxHOhVvOlCiSW9keqgiAADapnbefPMbb7xRN954o8PtExIS9Le//U2S9Nprr7mrrBabOCxBW/NK7bbZcfDchH50MAYAwD0Cvs9NTU2NKioqbF7ucnkP+6uD13tzc57bagAAoK0L+HAzd+5cWSwW6ysuLs5t75UU00lXxtt/NCU5NqMxAABomYAPN7NmzVJ5ebn1dejQIbe+35KJg2UOsX9Zr7+iu1trAACgLQv4cBMWFqbw8HCblztZzCFacd9VdttcmdDFrTUAANCWBXy48YYTzQz3nvrmdoaEAwDgJl4NN5WVlcrKylJWVpYkKTc3V1lZWTp48KCkc4+U0tLSbI6pb19ZWamioiJlZWXp22+/9XTpdjU35813BSf1wJvbPVQNAABti1eHgm/btk1jxoyx/j1jxgxJ0sSJE/XGG2/o2LFj1qBTLyUlxfrf27dv1/LlyxUfH6+8vDyP1OyI+jlv7A0L35xTol2Hy9TvogjPFQYAQBtgMgyjiRWRAlNFRYUsFovKy8vd2v/mo11H9eDynXbbmEOCtHnWWFnMIW6rAwCAQODM7zd9btzEkTlvqs/UacrSrR6oBgCAtoNw4yZJMZ2U3LX5WYi35peyYjgAAC5EuHGjebcPcKjd1rwS9xYCAEAbQrhxo/5xERqaFNVsu2f+17dGewEA4M8IN2626O5BSomLsNumsqZW/9x+2DMFAQAQ4Ag3bmYxh+ihscnNtnvsn197oBoAAAIf4cYDmpvUT5LO1klr9xzzQDUAAAQ2wo0HJMV0Ut+ezQ8Nn/t/ez1QDQAAgY1w4yFvTr5Kpmba5Jf8wLBwAABaiXDjIRZziF74ed9m2+WVEG4AAGgNwo0HDUro0mybhKjmJ/4DAABNI9x4UFJMJ41Kjmly/6jkGCVGE24AAGgNwo2HLRifoiEJkQ22t28XpKsSu9DnBgCAViLceJjFHKL2Ie0aXPhTZ+v0wqf7NGZehsa/8pXKq894pT4AAPwd4cbDcooqtT67SHV22mzOKdHUt7Z7rCYAAAIJ4cbD8k9UO9Ru04ESHlEBANAChBsPc2S24npbclgtHAAAZxFuPKx+xJQjF37P4TJ3lwMAQMAh3HjBgvEpGmFnSHi9NzMPKW1JJp2LAQBwAuHGCyzmEC2bPEQv3zWw2bbrs4v0wJt0LgYAwFGEGy+6sW8P/ahH52bbbc4p0S4eUQEA4BDCjZc9/7Pm15uSpN+uynJvIQAABAjCjZf1j4u0uyRDvezCKoaGAwDgAMKND1gwPkVXxjdckuFCrBgOAEDzCDc+wGIO0btTh+niGPuLZrYLMnmoIgAA/Bfhxof85seX2N3/+w+/YVg4AADNINz4kMt7hNvdf6CoSsOeX0fAAQDADsKND0mK6dRs35uq07Ua+OynOlTi2BpVAAC0NYQbHzNpWEKzbWoN6eYFX7q/GAAA/BDhxsf8KNb+o6l6FafO6svsIjdXAwCA/yHc+Jj6hTUdsXl/sZurAQDA/xBufNCC8SlKibM02+79rKNM7AcAwAUINz7IYg7Re9NGKOUi+wHnaPkpjZmXoQmvfsUIKgAA/o1w48Pe+K9UXdK1U7PtNh0o0ZRlWz1QEQAAvo9w48Ms5hAt+tUgh9puzSvVTxdu5A4OAKDNI9z4uPoOxo6svLDzUJmmr9jp/qIAAPBhhBs/sGB8igY5sLCmJK3PLqKTMQCgTfNquFm/fr3GjRun2NhYmUwmvf/++80ek5GRoYEDByosLEy9e/fWG2+84fY6vc1iDtGqB4ZpsIMB59sj5W6uCAAA3+XVcFNVVaX+/ftr4cKFDrXPzc3VzTffrDFjxigrK0uPPPKIpkyZok8++cTNlfqGxRMHa0AzI6gk6dUNuR6oBgAA32QyDMPwdhGSZDKZ9N577+m2225rss1jjz2mNWvWaM+ePdZtd955p8rKyrR27dpGj6mpqVFNTY3174qKCsXFxam8vFzh4Y7NBuxrbl+0SVvzSu22SZ85WonRHT1UEQAA7lVRUSGLxeLQ77df9bnZvHmzxo4da7Pt+uuv1+bNm5s8Zu7cubJYLNZXXFycu8t0u8Vpg5UUbbbb5qNdRz1UDQAAvsWvwk1BQYG6detms61bt26qqKjQDz/80Ogxs2bNUnl5ufV16NAhT5TqVhZziO4dlWS3zYuffq/bX97E0HAAQJvjV+GmJcLCwhQeHm7zCgSpiVHNttmaX6rR89IJOACANsWvwk337t1VWFhos62wsFDh4eHq0KGDl6ryjqSYThp2cfMBp7T6DLMXAwDaFL8KN0OHDtW6detstn322WcaOnSolyryrpfvGuTQCuJb80qZ+wYA0GZ4NdxUVlYqKytLWVlZks4N9c7KytLBgwclnesvk5aWZm3/wAMPKCcnR48++qi+++47/eMf/9A777yj3/zmN94o3+ss5hAtmzxEy/5rcLNtp6/YweMpAECb4NVws23bNqWkpCglJUWSNGPGDKWkpGj27NmSpGPHjlmDjiQlJiZqzZo1+uyzz9S/f3+9+OKLWrx4sa6//nqv1O8rRl3SVVc2M8HfniMVmvrWdg9VBACA9/jMPDee4sw4eX9SXn1Go+elq7SZuzPMfwMA8EcBO88NmmYxhyhj5hglRNnvWL0lp8RDFQEA4B2EmwBiMYfo/qt7223z6voc+t4AAAIa4SbApCZ2sbv/QHEVQ8MBAAGNcBNgkmI6KSXO/uKaW/NKdfvLm/T1oVKl7zvOMHEAQEChQ3EA+mjXUT24fKdTx4xKjtGC8SmymEPcVBUAAC1Hh+I27vIezoe2jfuLNX2Fc4EIAABfRLgJQEkxnRyaufh8tYah9dlFPKICAPg9wk2AWjA+RUOTml976kJ5JYQbAIB/I9wEKIs5RCvuu0rpM0cruVtHmRw87u//+p6h4gAAv0a4CXCJ0R317v3DNdLBx1Q7D5XrF4s2amXmQR5RAQD8EqOl2pDc4irllVTp1OlaTX1rh0PHDLs4Si/fNYhRVAAAr2K0FBqVGN1RYy7tqvahwQ4fs+lACaOoAAB+hXDTBsV3MTvVfn12kV7fkMtjKgCAXyDctEEtGSr+9Effasy8DKUtyaTDMQDApxFu2qgF41M07GLnh4qvzy7S1Le2u6EiAABco523C4B3WMwhWn7vVcotrtKWnBIt2ZCj7OOOPXbadKBEuw6Xqd9FEe4tEgCAFuDOTRuXGN1Rdw7ppXcfGK6k6I4OH/fbd752Y1UAALQc4QaSzt3JWTzxSofbZx+vpIMxAMAnEW5glRTTyaklG1iqAQDgiwg3sLHo7kEOj6RKiHL8MRYAAJ7iVLg5c+aMHn30UfXu3VtDhgzRa6+9ZrO/sLBQwcGOTxAH32Mxh2jZ5CFKnzlas39yubfLAQDAaU6Fmz/+8Y9atmyZHnjgAV133XWaMWOG7r//fps2bWw1h4CVGN1RiTH278zwWAoA4IucCjdvvfWWFi9erJkzZ+oPf/iDtm3bps8//1yTJk2yhhqTydH1p+HrmpvJ+B+f72dCPwCAz3Eq3Bw5ckR9+vSx/t27d29lZGRo06ZN+tWvfqXa2lqXFwjvqZ/JOLiJwLrjYBnrTgEAfI5T4aZ79+46cOCAzbaePXsqPT1dW7du1T333OPK2uADFoxP0cD4iEb31RqG1mcXMSQcAOBTnAo311xzjZYvX95ge2xsrD7//HPl5ua6rDD4Bos5RL8e09tum69ySjxUDQAAzXNq+YWnnnpK3333XaP7evbsqS+++EKfffaZSwqD72iu782s1bv11pZ8PffTvizJAADwOpPhxuFNN998sxYvXqwePXq46y2cVlFRIYvFovLycoWHh3u7HL+RtiRTG/cXq7aZfy6jkmO0YHyKLOYQD1UGAGgLnPn9duskfuvXr9cPP/zgzreAhywYn6LhvaObbfdldpHuWvIV/XAAAF7DDMVwSP3kfs//rK/ddoakPUcqNGZehtKWZDJUHADgcYQbOGVIYheH227ILtJdi8/dxckpqlT6vuPc0QEAuJ1THYqB+rlvNuwvUl0zvbXqJO05eu4uzvnolwMAcCfu3MBpC8anaERvxxbXbMyX2UX6xaJN3MUBALgF4QZOq+9/8+G04eoT6/yIM0NS9vFKjZmXoQmvfkW/HACAS7k13DzxxBPq0sXxPhrwL/3iIvTRQyOVPnO0+sSGt+gf06YDJSzhAABwKZeGm9LSUi1btsz696xZsxQREeHKt4APSozuqLemXKURyS17VMUSDgAAV3JpuDl48KAmTZrkylPCT9Q/qkqfOVp9eoYryMnF4bewhAMAwEWcCjcVFRV2XydPnmxREQsXLlRCQoLat2+v1NRUZWZmNtn2zJkzeuaZZ3TxxRerffv26t+/v9auXdui94XrJUZ31FuTr3K6w/Hjq3czLw4AwCWcWn4hKChIJlPT/y+5YRgymUyqra11uIC3335baWlpWrRokVJTUzV//nytWrVK+/btU9euXRu0f+yxx/Tmm2/q1Vdf1WWXXaZPPvlEM2bM0KZNm5SSktLs+7H8gufkFlcpr6RKCVEd9ei7X2trXqnd9kGSRiTHaNnkIZ4pEADgN5z5/XYq3FgsFv3ud79Tampqo/uzs7N1//33OxVuUlNTNXjwYL300kuSpLq6OsXFxWn69Ol6/PHHG7SPjY3V7373O02bNs267ec//7k6dOigN998s0H7mpoa1dTUWP+uqKhQXFwc4cbDvj5UplsXbnSo7YcPDmcBTgCADWfCjVOT+A0cOFCSdPXVVze6PyIiQs6sw3n69Glt375ds2bNsm4LCgrS2LFjtXnz5kaPqampUfv27W22dejQQRs2bGi0/dy5c/X00087XBPc40T1aYfbPvHebn00faQbqwEABDKn+txMmDBBYWFhTe7v3r275syZ4/D5iouLVVtbq27dutls79atmwoKCho95vrrr9df/vIXZWdnq66uTp999plWr16tY8eONdp+1qxZKi8vt74OHTrkcH1wnfguZofb7jlSoV2HytxXDAAgoDkVbu699149/PDDTe7v1q2bU+GmJf72t78pOTlZl112mUJDQ/Xggw9q0qRJCgpq/KOEhYUpPDzc5gXPq1+2IdhOn63z3fHKZpVXn2FNKgCA05wKN9dcc43Kyspc9ubR0dEKDg5WYWGhzfbCwkJ179690WNiYmL0/vvvq6qqSvn5+fruu+/UqVMnJSUluawuuMeC8Ska3jvaobY/nKnTwGc/1TUvfqFJr29llXEAgMOcCjcZGRk6fdrxvhPNCQ0N1aBBg7Ru3Trrtrq6Oq1bt05Dhw61e2z79u3Vs2dPnT17Vv/85z916623uqwuuMf5c+G8Pmmwkrt2stu+9oLuW+uzi/TAm9vdWCEAIBB4fVXwGTNmaOLEibryyis1ZMgQzZ8/X1VVVdbJANPS0tSzZ0/NnTtXkrRlyxYdOXJEAwYM0JEjR/T73/9edXV1evTRR735MeCExOiOSozuqC7mEN26cJNTx27OKVFucZUSozu6qToAgL9zOtx8++23TXb2rdevXz+Hz3fHHXeoqKhIs2fPVkFBgQYMGKC1a9daOxkfPHjQpj/NqVOn9OSTTyonJ0edOnXSTTfdpP/5n/9hmQc/1D8uUoMTIpud/+ZC97y2RY9ef5ku72kh5AAAGmjRJH6NHVK/3dlJ/DyNSfx8S3n1GY184XNVnDrbouNHJcdowfgUWcwhLq4MAOBL3DaJX1BQkDIzMxUTY39q/fj4eEdP6XGEG9/T2oAzNClKK+67ysVVAQB8idsm8ZOkXr16NbosAtBSFnOIvnz0Gk1ZulVb8517RCWd64ez61CZ+sVFuL44AIDf8XqHYkA6F3BWTR1mXY8qqmOonv3oW4f74/x2VZY+mzHavUUCAPyCU0PBr776aoWGhrqrFkCJ0R015tKu6ndRhFY9MEyD4yMd+keafbyKif4AAJKcvHOTnp4u6dzq39u3b1deXp5MJpMSExOVkpJid8VwoCUWTxys6St2an12UbNt80oYIg4AaMFjqfT0dE2ePFn5+fnWUVP1Aee1117TqFGjXF4k2q76if9yi6uUtmSLDpX+0GTbdkGEawCAk4+l9u/fr5/85CdKSEjQ6tWrtXfvXn377bdatWqVLrroIt10003KyclxV61owxKjO+rxGy6z2+ZP//cdyzMAAJwbCv7ggw9q7969Nssl1DMMQ2PHjtXll1+uBQsWuLRIV2IouP/KKarUNS9+0eT+IEkjkmO0bPIQzxUFAPAIZ36/nV5b6pFHHml0n8lk0iOPPGLtlwO4Wv3K4k09farTufWnVmYepHMxALRhTt25CQ8P165du5SQkNDo/tzcXPXr108nT550VX0ux50b/1ZefUZ3LflKe45UNNv2yvhITRqWoMt7WmQYhvJPVCshqiOdjgHAD7ltEr/KykqZzeYm95vNZlVXVztzSsApFnOI/n5nit3HU/W25ZdqWyOTArJkAwAENpcunFlcXNzqgoDm1D+e2ri/WLWO33i02ri/WNNX7NTvb7mcuzkAEIBYOBN+qbz6jMPz3ziiT2y4nvtpX5ZwAAAf5baFM/Pz8x1qx8KZ8JTc4ip9lVOiWat3u+R8hBwA8E1uCzfXXnutpk2bpp/97GeN7i8uLtaQIUN8eq4bwk1gSluS2eLHVI0h5ACAb3HbUPD09HT98pe/1Jw5cxrdX1tb6/DdHcCVFoxP0fDe0S47356jFbpl4Ub9ZMGX2nW4zGXnBQC4n1PhRpJefvllzZ8/Xz/96U9VVcVcIvAN9cs0pM8crZcmpGhwQqRLzrvnSIVueWmj0pZkMvsxAPgJpzsUFxQUqKSkRLfeeqvCwsL0wQcfKCkpSZJUWFio2NhYOhTDJ+QWVymvpEoJUedGQtX/95wPvtGG7CLVOXEuZj8GAO9y22Opej/60Y+0detWxcXFafDgwfrXv/7VokIBd0qM7qgxl3ZVYnRHm/9eMD5FI5JjnDpX/ezHzHwMAL6vReFGkiwWi9asWaN7771XN910k/7617+6si7AbeofYX344HD16enc3bu8EsINAPg6pybxM5lMDf5+/vnnNWDAAE2ZMkWff/65S4sD3KnfRRH6aPpI7Tpcpife2+3Qkg71j7gAAL7LqTs3TXXPufPOO7Vhwwbt3u2auUYAT6oPOc3dyYk0h6iLOdSDlQEAWsLpoeBdunRpdN+AAQO0fft2vf766y4pDPA0a8iZNlydwoIb7K+fFRkA4NucCjdXX3212rVr+klWVFSU0tLSWl0U4E2d2rdTZU3DEX90KgYA/+D0wplAoMs/YX9l+7ySKhmGwaKbAOCjCDfABeK7mO3u/0f6fm3NK7X+PSo5RgvGp8hiDnF3aQAAB7R4KDgQqJJiOmlUcoyCLxgdGGwyKdIcoh35ZTbbN2QXacrSrR6sEABgD+EGaERja1Wl9IpQafWZBotz1knaml+q2xdtYokGAPABTi2/EAhYfgHOOH8Jh7ySKk16vek7NEEmaURvlmgAAHdw5vebPjeAHfVLN0hNz/NUr874z2iqxOiOyimqpNMxAHgB4QZwUH1fnOYW3fzmSLnmfPCN1mcXWbcNjo/U4omD6XQMAB5AnxvACQvGp2hgfKTdNks35WnDecFGOtcnZ/if1mnXoTI3VgcAkAg3gFMs5hC9O3WYBidEKsh2MJWCTSYNTojU1vzSRu/sVNbU6paFG5W2JJOOxwDgRoQboAUWpw3WiN4xNtuG947WxGEJzR67YX8RyzgAgBvR5wZoAYs5RMsmD7EZTVXfibg59R2PX9+Qo9GXdaOzMQC4GEPBARf7xcubtC2/tPmG/8YMxwDQPGd+v33isdTChQuVkJCg9u3bKzU1VZmZmXbbz58/X5deeqk6dOiguLg4/eY3v9GpU6c8VC1g35KJgxXpRFDZuL+Yx1QA4EJeDzdvv/22ZsyYoTlz5mjHjh3q37+/rr/+eh0/frzR9suXL9fjjz+uOXPmaO/evVqyZInefvttPfHEEx6uHGicxRyijJljNDjB/qiqerWGwWrjAOBCXg83f/nLX3Tvvfdq0qRJuvzyy7Vo0SKZzWa99tprjbbftGmThg8frgkTJighIUHXXXedxo8f3+zdHsCTLOYQrXpgmF6+K8XhY/JKCDcA4ApeDTenT5/W9u3bNXbsWOu2oKAgjR07Vps3b270mGHDhmn79u3WMJOTk6OPP/5YN910U6Pta2pqVFFRYfMCPOXGvrEalRzj0P/QEqLoWAwAruDVcFNcXKza2lp169bNZnu3bt1UUFDQ6DETJkzQM888oxEjRigkJEQXX3yxRo8e3eRjqblz58pisVhfcXFxLv8cgD0LxqdoRHJMk/uDTSaNSo6xjprKKapU+r7jPKYCgBbyu6HgGRkZeu655/SPf/xDqamp2r9/vx5++GE9++yzeuqppxq0nzVrlmbMmGH9u6KigoADjzp/2Pg3R8u1dFOetub9ZzTV8N7RWjA+RWXVp/XQiiybZRsaG0mVU1SpLbknZJKUmhTFUHIAuIBXw010dLSCg4NVWFhos72wsFDdu3dv9JinnnpKv/rVrzRlyhRJUt++fVVVVaX77rtPv/vd7xQUZHszKiwsTGFhYe75AIAT6hfh/Em/2Abz40hS2pJMbdxfbHNM/UiqZZOHqKz6tKa+uUObc0ps2qTERWjyyERdEWsh6ACAvPxYKjQ0VIMGDdK6deus2+rq6rRu3ToNHTq00WOqq6sbBJjg4GBJza/aDPiKxOiOGnNpV5tHUeuzi1R7wb/h80dSPbQiq0GwkaSdh8r04PKdGjMvg6UdAEA+MFpqxowZevXVV7V06VLt3btXU6dOVVVVlSZNmiRJSktL06xZs6ztx40bp5dfflkrV65Ubm6uPvvsMz311FMaN26cNeQA/ib/RLXd/V/llNg8rmoKc+YAgA/0ubnjjjtUVFSk2bNnq6CgQAMGDNDatWutnYwPHjxoc6fmySeflMlk0pNPPqkjR44oJiZG48aN0x//+EdvfQSg1eK7mO3uN9nd+x/n3+nhERWAtorlFwAfUd/n5vxHU8Emk4b3jtbvb7lc17z4hcPnen3SYI25tKs7ygQAr/C75RcAnBsyPrx3tM22+pFUSTGdNMrOcPIL/SN9v74+VMqQcgBtEnduAB/T2EgqSSqvPqMH3tzeaKfi5vSJDddzP+2rfnERLqwUADzHmd9vwg3gZ3KLq/RVTolOna7VP3cc1p6jjs+6fWV8pCYNS9DlPRk2DsC/OPP77fUOxQCcUz9fjiQlxHTUpNe3OnzstvxSbcs/N4Fgn57/vptzUYQ7ygQAryHcAH6suVFW9uw5UqFbXtqoUckx+u11yTpRfabBozAA8EeEG8CP1Xc0vnCUlTPWZxc1u+QDAPgTRksBfq6xUVatwUSAAPwdd24AP3f+wpx5JVWKModq3qffOzSjcWOYCBCAvyPcAAHi/I7GyyYP0a7DZXrivd3ac8Tx0VTnyys5F25yiiqVf6Ka/jgA/AbhBghQ/S6K0EfTRyq3uErfHC3X0k152ppX6vDxp07XKm1JJv1xAPgd5rkB2pBdh/59N8eBuXH69AzX3qMnG10OYtnkIe4sEwAaYBI/Owg3QP1EgMWatXpPi45PnzmaR1QAPIq1pQDYlRjdUeOHxGtUcoyCTbZrjgebTOoTa/+LI6+E9aoA+C7CDdCGNbVY5x9/2tfucQlR3LUB4LvoUAy0YRcOI68fEZVTVGn3uJOnznioQgBwHuEGgM0wcknKP1Ftt/0T7+3WR9NHOnTunKJKbcktkWTSVUlR9NUB4HaEGwANNLdm1Z4jFc1O8ldWfVq/fmuHNh0osdk+NClKi+4epJKqGubPAeAWhBsADSTFdFKf2HC7Q8brJ/lrykMrshoEG0nanFOi0fPSVVr9n0dbzJ8DwJXoUAygUa3pVJxTVGl3+Yfzg43EelYAXItwA6BR/eMiNCo5RkG2I8UVbDJpVHKM3bs2zfXZudD561kBQGsRbgA0acH4FI3oHWOzbXjvaC0Yn2L3uOb67DRlS07Dx1gA4CxmKAbQrAuHijviwnWpHDUqOUZ3DolT9vGTGtgrUiOTY5o/CEDAY/kFOwg3gGeUV5/R1Le2N+hU3C5IOlvn+HkizSH6cNoIxUW17G4QgMBAuLGDcAN4Vm5xlbbklMiQ1DOig9Jey3T6HJHmEO2cfZ3riwPgN5z5/WYoOAC3On+CwPR9x1t0jtLqM/oyu4hHVAAcQodiAB7T0o7GkrTpQLELKwEQyAg3ADwmKaZToyuRO2JDtm24ySmqVPq+41r//XGl7zvOMHIAVjyWAuBRC8anaPqKnU6PpNr97yUfIs0hemhFVqPHD06I1I19uqtDaDv1jOigWsNgeQegDSLcAPCoxlYil84t57D3aIVe+GRfk8fmlVRpzgd52ri/8UdUW/NKtTWvtMF2lncA2hYeSwHwisTojhpzaVdrh+Mxl3bVDX262z0m2GTS+uwi1To5yHN9dpGmvrW9NeUC8COEGwA+o6k+OfVLPjgbas636UCJ1u4+1toSAfgBwg0An7JgfIqG94622Va/5ENrRltJ0gNv7dAvXt6kNV8fpQMyEMCYxA+AT2pqyYe0JZnauL+4VXdx6l0ZH6lJwxJ0eU8LnY4BH8cMxXYQbgD/Vl59pkWjrZpDp2PAtxFu7CDcAIGh/s5OuyCTKqrPaPGGXO08VNbi8wWbTBreO1rLJg9xXZEAXIblFwAEvPOXdZCkm/vHKre4SunfHde8T79T9WknVueUVGsYWp9dpNziKh5RAX6ODsUAAkZidEf914hEbX58rPrGtuzO7PTlO1Refcb6d/1MyHRABvyHT4SbhQsXKiEhQe3bt1dqaqoyM5teNXj06NEymUwNXjfffLMHKwbgyyzmEP3vQyOV0ivC6WO/PVqh6St2qqz6tNKWZOqaF7/QpNe3asy8DKUtybQJPgB8k9fDzdtvv60ZM2Zozpw52rFjh/r376/rr79ex483vnrw6tWrdezYMetrz549Cg4O1u233+7hygH4ujfuGaJRTq4kXqdzk/7du2xbg5mQN+wv0vQVO11YIQB38HqH4tTUVA0ePFgvvfSSJKmurk5xcXGaPn26Hn/88WaPnz9/vmbPnq1jx46pY8fmn5PToRhoe84fVv5VTolmrd7dqvN9OG24+sVFuKY4AA5x5vfbq3duTp8+re3bt2vs2LHWbUFBQRo7dqw2b97s0DmWLFmiO++8s8lgU1NTo4qKCpsXgLbl/KUeUhO7tPp8ExZ/xeMpwId5NdwUFxertrZW3bp1s9nerVs3FRQUNHt8Zmam9uzZoylTpjTZZu7cubJYLNZXXFxcq+sG4L+aWuKhXrDJpCvjI+2eo7KmVlOWbpVEh2PAF3m9z01rLFmyRH379tWQIU3PSzFr1iyVl5dbX4cOHfJghQB8UWNLPNQb3jtaSyYOVp+e9m97b80v1e2LNtHhGPBBXp3nJjo6WsHBwSosLLTZXlhYqO7d7a8OXFVVpZUrV+qZZ56x2y4sLExhYWGtrhVA4LCYQ7Rs8hCbiQDP1hk2Sz388bY+unXhJrvn2Z5favP3huwi3bX4Ky2YMNB6npyiSuWfqG6wjAQA9/FquAkNDdWgQYO0bt063XbbbZLOdShet26dHnzwQbvHrlq1SjU1Nbr77rs9UCmAQHThRIDn6x8XqcEJkdqaV9rofkmqu2A4Rp2kPUcrNGZehoYmRclkOrcaeT2WeAA8w+uPpWbMmKFXX31VS5cu1d69ezV16lRVVVVp0qRJkqS0tDTNmjWrwXFLlizRbbfdpqioKE+XDKCNWJw2WJGNBJHGe+vY2pxTYhNsJOnL/UWasmyri6oD0BSvL79wxx13qKioSLNnz1ZBQYEGDBigtWvXWjsZHzx4UEFBthls37592rBhgz799FNvlAygjbCYQ5Qxc4ymLN2qrec9ghoUH6lt+U3f0WmKYUhb80r104Ub9cakISqpqlH+iWoFm0yqNQweXQEu4vV5bjyNeW4AtMT5c+UkRndU2pJMbdxfrNoWfoVGmkNU2kjn4+SunfTi7f2ZRwe4AKuC20G4AeAK5dVnNH3FTq3PLnLL+YddHKWX7xpE/xzg3/xmEj8A8Ff1I67SZ45Wn57hCnKkI44TNh0o0b3Ltrn2pEAbQbgBgFZIjO6otyZfpRG9bdewSomztPrcmXkntOtQWavPA7Q1PJYCABdprF9Oax9bJXTpoIxHr3FRhYD/4rEUAHjB+WtYSedmQh6a1HC6CkuHEIe/fPNO/KBdh8sksdQD4Cju3ACAm+UWV+mrnBKZJKUmRamLOdSpzsiX9eisrp3a27RnQkC0NYyWsoNwA8BX5BZX6Zuj5Zq+fKea+yIOMtnOiBxsMml472gtm9z02npAIHHm99vrk/gBQFtVv/xD/54RunpeeoPlHM534b5aw9D67CLlFlc1OvFfTlGltuSWqOjkaXXtHKbUpCgmCESbQbgBAC+LizLrvV8P160LNzp9bF6Jbbgpqz6tX7+1o8HSD5LUPTxMvxh0kX4+KI6gg4BGh2IA8AH94yI0KjmmwXw5zX1JJ0TZhpSHVmQ1GmwkqaCiRi+lH9CYeRka99KXKm9khmQgEBBuAMBHLBif0mC+nIHxkQ4fn1NU6XAn5d2HKzTyhc8JOAhIPJYCAB9RP+vx+fPl5JVUadLrTa8kfv5jqfwT1U69X8Wpsxr/yiZ9/MjVraob8DWEGwDwMfUdjSWpuQGt5z+Wiu9idvq9vi2o1K7DZep3UYTTxwK+isdSAODDkmI6aVRyjIJNtp1xgk0mjUqOsekYXN/WWVPf3N7qOgFfQrgBAB+3YHyKhveOttk2vHe0FoxPabTtsIsbzopsz5GyU9Y1rHKKKrUi86AWrPteCz7/XisyDzIjMvwOk/gBgJ+4cO2q5tpuySnR/sJKLd6Y2+y5L+veWZHmUG3OaXyk1dCkKC26exAzIsNrmKHYDsINgLbmUEm1Rv45vdXnGZoUpRX3XeWCigDnsXAmAMAqLsqsj6ePaPV5NueU8IgKfoHRUgDQBlze06IPpg3TrQs3teo8Gd8Vyri0K0s7wKfxWAoA2pC0JZnakF2kuvO2BUk2f9vTISRIP5xp2DousoOmjEhQr+hODvUJApxFnxs7CDcA2rLy6jOavmKnzUzGo5JjdLaursllG1piVHKMFoxPoQMyXIZwYwfhBgAajrwqrz6jB97c3uRoKWcFSbo8NlwLJgzkLg5cgnBjB+EGAJqWW1yld7cd0sKMAy47Z5+e4Xrup32ZBRmtwmgpAECLJEZ31P+74bJzK5S76Jx7jlTolpc2Km1JJgt1wiMINwCABhaMT9GIC5ZyiGxl/5kvs4s0Zdm5RUBziiqVvu84Q8vhFjyWAgA06fy+OV3MoZr61vZWdzwOb99OFafOWv8enBCpxWmDVVJVo/wT1Yy2QqPoc2MH4QYAWqd+aYfswpNasfWQqk/Xtvqc7YJMOlv3n58jRlvhQoQbOwg3AOBaX2YXacfBUsVaOmjp5jx9e7RCdS74ZUmK7qj7RiUxSSAkEW7sItwAgPs0No+OK/yoe2f96Rf9GHHVhhFu7CDcAID77TpUpt+u+lrZxytdet4+seeGlXdq347+OW0M4cYOwg0AeM7tL2/S9vxSh5d3aIn6wNMvLsKN7wJvY54bAIBPWDxxcIMh5e2CTC59jz1HK3TLQubRwX9w5wYA4HYXDimfsnSrtuaXuvQ9TKZzd3FmXHcpj6sCEI+l7CDcAIBvqA88UR1DNe+T713eCbl+/hyGkwcGwo0dhBsA8E25xVX69ki5Xt2Qq6xDZS45Z6ewYD3/8366ItbCnRw/R7ixg3ADAL4vt7hK6d8VakXmIZeNuLqw43FOUSUjrvwI4cYOwg0A+Jddh8v0xHu7tedIhUvON+ziKBmGtDnnP8tIMCOy7/O70VILFy5UQkKC2rdvr9TUVGVmZtptX1ZWpmnTpqlHjx4KCwvTJZdcoo8//thD1QIAPKnfRRH6aPpIpc8crdcnDVb6zNH68MHhSu7aqUXn23SgxCbYSNL67CJNfG0Li3kGCK/fuXn77beVlpamRYsWKTU1VfPnz9eqVau0b98+de3atUH706dPa/jw4erataueeOIJ9ezZU/n5+YqIiFD//v2bfT/u3ABA4HDXPDqD4yO1eCKdkX2JXz2WSk1N1eDBg/XSSy9Jkurq6hQXF6fp06fr8ccfb9B+0aJF+vOf/6zvvvtOISHO/6Mj3ABA4HDXcg/Suc7IGx+7ltXKfYTfhJvTp0/LbDbr3Xff1W233WbdPnHiRJWVlemDDz5ocMxNN92kLl26yGw264MPPlBMTIwmTJigxx57TMHBwQ3a19TUqKamxvp3RUWF4uLiCDcAEEByi6v0zdFyPfbuLlW5YJXyesFBUu15t4Xom+M9ftPnpri4WLW1terWrZvN9m7duqmgoKDRY3JycvTuu++qtrZWH3/8sZ566im9+OKL+sMf/tBo+7lz58pisVhfcXFxLv8cAADvSozuqJ/0i9Wmx6/V4PhIl5239oLnXRv2F2n6ip0uOz/co523C3BWXV2dunbtqldeeUXBwcEaNGiQjhw5oj//+c+aM2dOg/azZs3SjBkzrH/X37kBAAQeizlEq6YOs04QWHOmVi+l77cZadU5rJ1O1pxt0fnrjHOdjzftL9aw3tGuKhsu5tVwEx0dreDgYBUWFtpsLywsVPfu3Rs9pkePHgoJCbF5BPWjH/1IBQUFOn36tEJDQ23ah4WFKSwszPXFAwB8VmL0f/rH3NCnR4PlH0bPS1dpK9ahuu9/tunDB0c06Ivzxb7jyjpcpoG9IjXygjW14DleDTehoaEaNGiQ1q1bZ+1zU1dXp3Xr1unBBx9s9Jjhw4dr+fLlqqurU1DQuadq33//vXr06NEg2AAAINmGHUnKmDmmVetbVdbU6poXv7D+fWV8pPYfr1TZD/8JTJ3CgvXKr67kDo8XeH2emxkzZujVV1/V0qVLtXfvXk2dOlVVVVWaNGmSJCktLU2zZs2ytp86dapOnDihhx9+WN9//73WrFmj5557TtOmTfPWRwAA+Jn6x1fpM0frhV/0VeewhgNSnLEtv9Qm2EjnAtCExVtYrdwLvN7n5o477lBRUZFmz56tgoICDRgwQGvXrrV2Mj548KD1Do0kxcXF6ZNPPtFvfvMb9evXTz179tTDDz+sxx57zFsfAQDgp+rv6Pzyyl5au+eYnvnoGx0tq2n+QCd8mX2uE/KyyUNcel40zevz3Hga89wAAOw5v3/Oz/6xsVV9c86XPnM08+S0gjO/316/cwMAgC85v3/Oh9NG6JaFG1wScPJKqmzCTf3CncEmk2oNQ8crTqmg4hSdkV2AcAMAQBPioszaOfs6fZldpB0HSzWwV6ReXZ+rjfuLVevkg4+EqHPBpqz6tB5akWV3VuVIc4g+nDZCcVHmVtXfVhFuAABoxsjkGOvdlH49Ixos+RDePlgVpxybGfmhFVnauL/YbpvS6jO68e/r9Y+7BqnWMKx3d1gCwjGEGwAAnGAxh2jZ5CEN5s65a8lXNpMFXiivpEqGYTi8DlZlTa3SXstssL1vz3Ddf/XFuiLWQtBpAuEGAIAWuHDunL/fmWIz982FEqI6Kq+kqtXvu/tIhR5cfm4JiD49w9W3Z7h6Rph1c79Yws6/EW4AAHCBpJhOGpUc06A/TrDJpOG9o5UY3VGuHqC850iF9W7RvE+/15CELno17co2v7Cn1yfxAwAgUCwYn6LhF8xIPLx3tBaMT5H0nwAUbDK55f0z807o7iVf6W/rvteXDj7+CkTMcwMAgIud3x/nwkdF5dVnGnRIdpdOYcF6elwfdekc6vedkZ35/SbcAADgBfUBqF2QSWfrDBWfrNFLn2fr4Ikf5K4f5sHxkVo8cbBfPrYi3NhBuAEA+CpP3NXpFBas5fdepX4XRbjtPdyBcGMH4QYA4OvOv6tT/sMZ/fcXB7TbzjDzlkju2knXXd5NF3Ux66qkKCVGd1ROUaW25J6QSVLqv7f5CsKNHYQbAIA/2nWoTE+8t1t7jro25NTr3D5YJy+YiDAlLkKTRyb6xJw6hBs7CDcAAH92fmflh1bs0J4jFW7ro3O+UckxWjA+xWv9dZz5/WYoOAAAfiQxuqPGXNpVidEd9ebkqzy2yObG/cWavmKnR96rtZjEDwAAP9XYUhD7Cio09/++U35JtUvfq/bfS0fkFlc1eET1xb7jyjpc5jMrmhNuAADwc+cvBZEY3VE39Omh3OIqfXO03OWdkb85Wm59r/ySKt22cKNKq89Y94e3b6c100d6dUVzHksBABCAEqM76if9YvW/00fqw2nD1SfWNf1Ml27Ks/73hcFGkipOndXVf07X2j3HXPJ+LUG4AQAgwPWLi9BHD50LOZd179xoG0cDwda8UuUWV+mLfccbBJt6dZIeeHOHUp75VIdc/HjMETyWAgCgjegXF6G1j4xSbnGVvsopUUlljaI6hemqpCh1MYdqyrKt2ppX2ux58kqqtOtwWbPtSqvP6JaFG7Rz9nUuqN5xhBsAANqY8/vonG/VA8OswWfW6t1NHp8Q1dHhOz2l1Wf0ZXaRRzsa81gKAABYJUZ31PghvRpdvTzYZNKo5BglRnfU1Zd2VXh7x+6R7DjY/N0gVyLcAACABhaMT9Hw3tE224b3jtaC8SnWv9dMH6l2QaYLD21gYK9Il9dnDzMUAwCAJp0/h05jj7LKq8/o7iVfNTncPNIc4pI+N878ftPnBgAANKmp/jn1LOYQ/e/0kdqUXaz73tymypr/rE8VaQ7Rh9NGeKJMG9y5AQAALvNldpF2HCx1+WzF3LkBAABeMTI5xutLMNChGAAABBTCDQAACCiEGwAAEFAINwAAIKAQbgAAQEAh3AAAgIBCuAEAAAGFcAMAAAIK4QYAAAQUwg0AAAgobW75hfqltCoqGl+9FAAA+J76321HlsRsc+Hm5MmTkqS4uDgvVwIAAJx18uRJWSwWu23a3KrgdXV1Onr0qDp37iyTyeTSc1dUVCguLk6HDh1ixfEW4Pq1HNeudbh+rcP1ax2un2MMw9DJkycVGxuroCD7vWra3J2boKAgXXTRRW59j/DwcP6BtgLXr+W4dq3D9Wsdrl/rcP2a19wdm3p0KAYAAAGFcAMAAAIK4caFwsLCNGfOHIWFhXm7FL/E9Ws5rl3rcP1ah+vXOlw/12tzHYoBAEBg484NAAAIKIQbAAAQUAg3AAAgoBBuAABAQCHc2LFw4UIlJCSoffv2Sk1NVWZmpt32q1at0mWXXab27durb9+++vjjj232G4ah2bNnq0ePHurQoYPGjh2r7Oxsd34Er3L19bvnnntkMplsXjfccIM7P4JXOXP9vvnmG/385z9XQkKCTCaT5s+f3+pz+jtXX7/f//73Df79XXbZZW78BN7jzLV79dVXNXLkSEVGRioyMlJjx45t0J7vvtZdv7b23ecSBhq1cuVKIzQ01HjttdeMb775xrj33nuNiIgIo7CwsNH2GzduNIKDg40XXnjB+Pbbb40nn3zSCAkJMXbv3m1t8/zzzxsWi8V4//33ja+//tq45ZZbjMTEROOHH37w1MfyGHdcv4kTJxo33HCDcezYMevrxIkTnvpIHuXs9cvMzDRmzpxprFixwujevbvx17/+tdXn9GfuuH5z5swxrrjiCpt/f0VFRW7+JJ7n7LWbMGGCsXDhQmPnzp3G3r17jXvuucewWCzG4cOHrW347mvd9WtL332uQrhpwpAhQ4xp06ZZ/66trTViY2ONuXPnNtr+l7/8pXHzzTfbbEtNTTXuv/9+wzAMo66uzujevbvx5z//2bq/rKzMCAsLM1asWOGGT+Bdrr5+hnHuf+C33nqrW+r1Nc5ev/PFx8c3+uPcmnP6G3dcvzlz5hj9+/d3YZW+qbX/Ts6ePWt07tzZWLp0qWEYfPe19voZRtv67nMVHks14vTp09q+fbvGjh1r3RYUFKSxY8dq8+bNjR6zefNmm/aSdP3111vb5+bmqqCgwKaNxWJRampqk+f0V+64fvUyMjLUtWtXXXrppZo6dapKSkpc/wG8rCXXzxvn9FXu/KzZ2dmKjY1VUlKS7rrrLh08eLC15foUV1y76upqnTlzRl26dJHEd19rr1+9tvDd50qEm0YUFxertrZW3bp1s9nerVs3FRQUNHpMQUGB3fb1/9eZc/ord1w/Sbrhhhu0bNkyrVu3Tn/605/0xRdf6MYbb1Rtba3rP4QXteT6eeOcvspdnzU1NVVvvPGG1q5dq5dfflm5ubkaOXKkTp482dqSfYYrrt1jjz2m2NhY6w88332tu35S2/nuc6U2tyo4/Nedd95p/e++ffuqX79+uvjii5WRkaFrr73Wi5WhLbjxxhut/92vXz+lpqYqPj5e77zzjiZPnuzFynzH888/r5UrVyojI0Pt27f3djl+p6nrx3ef87hz04jo6GgFBwersLDQZnthYaG6d+/e6DHdu3e3277+/zpzTn/ljuvXmKSkJEVHR2v//v2tL9qHtOT6eeOcvspTnzUiIkKXXHJJQP37a821mzdvnp5//nl9+umn6tevn3U7332tu36NCdTvPlci3DQiNDRUgwYN0rp166zb6urqtG7dOg0dOrTRY4YOHWrTXpI+++wza/vExER1797dpk1FRYW2bNnS5Dn9lTuuX2MOHz6skpIS9ejRwzWF+4iWXD9vnNNXeeqzVlZW6sCBAwH176+l1+6FF17Qs88+q7Vr1+rKK6+02cd3X+uuX2MC9bvPpbzdo9lXrVy50ggLCzPeeOMN49tvvzXuu+8+IyIiwigoKDAMwzB+9atfGY8//ri1/caNG4127doZ8+bNM/bu3WvMmTOn0aHgERERxgcffGDs2rXLuPXWWwN6OKQrr9/JkyeNmTNnGps3bzZyc3ONf/3rX8bAgQON5ORk49SpU175jO7k7PWrqakxdu7caezcudPo0aOHMXPmTGPnzp1Gdna2w+cMJO64fr/97W+NjIwMIzc319i4caMxduxYIzo62jh+/LjHP587OXvtnn/+eSM0NNR49913bYYqnzx50qYN330tu35t7bvPVQg3dixYsMDo1auXERoaagwZMsT46quvrPuuvvpqY+LEiTbt33nnHeOSSy4xQkNDjSuuuMJYs2aNzf66ujrjqaeeMrp162aEhYUZ1157rbFv3z5PfBSvcOX1q66uNq677jojJibGCAkJMeLj44177703IH+Y6zlz/XJzcw1JDV5XX321w+cMNK6+fnfccYfRo0cPIzQ01OjZs6dxxx13GPv37/fgJ/IcZ65dfHx8o9duzpw51jZ897X8+rXF7z5XMBmGYXj2XhEAAID70OcGAAAEFMINAAAIKIQbAAAQUAg3AAAgoBBuAABAQCHcAACAgEK4AQAAAYVwAwAAAgrhBgAABBTCDQCPyMjIkMlkavI1ZswY5eXl2Wzr3LmzrrjiCk2bNk3Z2dnWc40ePdruuUaPHi1JeuWVVzR69GiFh4fLZDKprKzMqZr/+Mc/atiwYTKbzYqIiHDdxQDgVoQbAB4xbNgwHTt2rMHrv//7v2UymfTrX//a2vZf//qXjh07pq+//lrPPfec9u7dq/79+1tXW169erX1+MzMTJtjjh07ptWrV0uSqqurdcMNN+iJJ55oUc2nT5/W7bffrqlTp7by0wPwJNaWAuA1e/fuVWpqqh566CH94Q9/UF5enhITE7Vz504NGDDA2q6urk7XXnutcnNzdeDAAQUHB1v3NXXM+TIyMjRmzBiVlpa26A7MG2+8oUceecTpOz8AvIM7NwC8oqysTLfeeqtGjx6tZ5991m7boKAgPfzww8rPz9f27ds9VCEAf0W4AeBxdXV1mjBhgtq1a6e33npLJpOp2WMuu+wySefu1ACAPe28XQCAtueJJ57Q5s2blZmZqc6dOzt0TP0TdEeCEIC2jXADwKNWrlypefPmac2aNUpOTnb4uL1790qSEhMT3VUagADBYykAHpOVlaXJkyfr+eef1/XXX+/wcXV1dfr73/+uxMREpaSkuLFCAIGAOzcAPKK4uFi33XabRo8erbvvvlsFBQU2+88fAVVSUqKCggJVV1drz549mj9/vjIzM7VmzRqbds0pKChQQUGB9u/fL0navXu3OnfurF69eqlLly7NHn/w4EGdOHFCBw8eVG1trbKysiRJvXv3VqdOnRyuA4BnEW4AeMSaNWuUn5+v/Px89ejRo8H++Ph4ZWRkSJLGjh0rSTKbzYqPj9eYMWP0yiuvqHfv3k6956JFi/T0009b/x41apQk6fXXX9c999zT7PGzZ8/W0qVLrX/X3zVKT0+3ThQIwPcwzw0AAAgo9LkBAAABhXADoE167rnn1KlTp0ZfN954o7fLA9AKPJYC0CadOHFCJ06caHRfhw4d1LNnTw9XBMBVCDcAACCg8FgKAAAEFMINAAAIKIQbAAAQUAg3AAAgoBBuAABAQCHcAACAgEK4AQAAAeX/A/vM1buFRQlBAAAAAElFTkSuQmCC",
-      "text/plain": [
-       "<Figure size 640x480 with 1 Axes>"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
+   "outputs": [],
    "source": [
     "result_df = pandas.DataFrame(json.loads(getattr(getattr(run_result.data, 'result'), 'result_json'))['logs']['result'])\n",
     "result_df.plot.scatter('ZDT1_1', 'ZDT1_2')"
@@ -545,7 +465,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.18"
+   "version": "3.12.1"
   }
  },
  "nbformat": 4,

--- a/notebooks/quenc_example.ipynb
+++ b/notebooks/quenc_example.ipynb
@@ -60,14 +60,18 @@
   },
   {
    "cell_type": "code",
+   "execution_count": null,
+   "id": "1697b239ac709f6f",
+   "metadata": {
+    "collapsed": false,
+    "jupyter": {
+     "outputs_hidden": false
+    }
+   },
    "outputs": [],
    "source": [
     "    print(f\"Running experiment within: Org {org_sample.id}, Proj {proj_sample.id} and Exp {exp_sample.id}`\")"
-   ],
-   "metadata": {
-    "collapsed": false
-   },
-   "id": "1697b239ac709f6f"
+   ]
   },
   {
    "cell_type": "code",
@@ -111,9 +115,7 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "235e707b",
-   "metadata": {
-    "scrolled": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "    result = run.poll()\n",
@@ -137,7 +139,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.12"
+   "version": "3.11.6"
   },
   "vscode": {
    "interpreter": {

--- a/notebooks/tetraopt_example.ipynb
+++ b/notebooks/tetraopt_example.ipynb
@@ -60,14 +60,18 @@
   },
   {
    "cell_type": "code",
+   "execution_count": null,
+   "id": "ab114f0abca6b084",
+   "metadata": {
+    "collapsed": false,
+    "jupyter": {
+     "outputs_hidden": false
+    }
+   },
    "outputs": [],
    "source": [
     "    print(f\"Running experiment within: Org {org_sample.id}, Proj {proj_sample.id} and Exp {exp_sample.id}`\")"
-   ],
-   "metadata": {
-    "collapsed": false
-   },
-   "id": "ab114f0abca6b084"
+   ]
   },
   {
    "cell_type": "code",
@@ -120,9 +124,7 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "235e707b",
-   "metadata": {
-    "scrolled": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "    result = run.poll()\n",
@@ -156,7 +158,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.12"
+   "version": "3.11.6"
   },
   "vscode": {
    "interpreter": {

--- a/notebooks/ts_hqlstm_example.ipynb
+++ b/notebooks/ts_hqlstm_example.ipynb
@@ -12,7 +12,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": null,
    "id": "bf7c0de1-c5e4-46eb-a0d1-dbe6eb8585e0",
    "metadata": {},
    "outputs": [],
@@ -45,34 +45,28 @@
   },
   {
    "cell_type": "code",
+   "execution_count": null,
+   "id": "df2f2499b8676aef",
+   "metadata": {
+    "collapsed": false,
+    "jupyter": {
+     "outputs_hidden": false
+    }
+   },
    "outputs": [],
    "source": [
     "with TQ42Client() as client:\n",
     "    org_sample = list_all_organizations(client=client)[0] \n",
     "    proj_sample = list_all_projects(client=client, organization_id=org_sample.id)[0]\n",
     "    exp_sample = list_all_experiments(client=client, project_id=proj_sample.id)[-1]"
-   ],
-   "metadata": {
-    "collapsed": false
-   },
-   "id": "df2f2499b8676aef"
+   ]
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": null,
    "id": "1e2c2381-bed3-4e2b-9e00-48db34e49a95",
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "<tq42.project.Project object at 0x1086cad90>\n",
-      "<tq42.organization.Organization object at 0x108286520>\n",
-      "<tq42.experiment.Experiment object at 0x108278cd0>\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "    print(f\"Running experiment within: Org {org_sample.id}, Proj {proj_sample.id} and Exp {exp_sample.id}`\")"
    ]
@@ -87,7 +81,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": null,
    "id": "4d3acb6a-33a0-4cf4-b9bc-ecb038960f7d",
    "metadata": {},
    "outputs": [],
@@ -125,31 +119,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": null,
    "id": "169fadb5-49f6-4f5b-97a6-3268db5b78c3",
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "id: \"640ec1a4-2f1f-4a1f-bec7-fbeaa5c0d06d\"\n",
-      "experiment_id: \"811fd59b-2b51-42ea-b573-b5aebb0d5d7a\"\n",
-      "sequential_id: 26\n",
-      "status: QUEUED\n",
-      "algorithm: TS_HQLSTM_TRAIN\n",
-      "hardware: SMALL\n",
-      "metadata: \"{\\\"parameters\\\":{\\\"input_width\\\":1,\\\"label_width\\\":1,\\\"hidden_size\\\":17,\\\"num_qubits\\\":8,\\\"depth\\\":7,\\\"dropout_coef\\\":0.24,\\\"num_epochs\\\":5,\\\"batch_size\\\":20,\\\"learning_rate\\\":0.05,\\\"optim\\\":\\\"ADAM\\\",\\\"loss_func\\\":\\\"MSE\\\",\\\"train_model_info\\\":null,\\\"nqlayers\\\":3},\\\"inputs\\\":{\\\"data\\\":{\\\"storage_id\\\":\\\"fc4310c5-a2a3-43cd-990c-8dd2b1aec994\\\"}}}\"\n",
-      "result {\n",
-      "}\n",
-      "created_by: \"35dc8cba-b06d-4f15-b9bc-588f608789de\"\n",
-      "created_at {\n",
-      "  seconds: 1705664553\n",
-      "  nanos: 50279143\n",
-      "}\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "    run = ExperimentRun.create(\n",
     "        client=client,\n",
@@ -172,7 +145,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": null,
    "id": "417ae287-2af1-41e2-bb3e-cc4c17d2410c",
    "metadata": {},
    "outputs": [],
@@ -195,7 +168,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
+   "execution_count": null,
    "id": "c2565e58-b31b-4b32-8fc7-b33953c6787f",
    "metadata": {},
    "outputs": [],
@@ -228,31 +201,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 18,
+   "execution_count": null,
    "id": "e84543c0-2810-401b-a865-53a764876981",
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "id: \"5e799d86-6ee9-4c90-99bd-5ffb2a3d368a\"\n",
-      "experiment_id: \"811fd59b-2b51-42ea-b573-b5aebb0d5d7a\"\n",
-      "sequential_id: 27\n",
-      "status: QUEUED\n",
-      "algorithm: TS_HQLSTM_EVAL\n",
-      "hardware: SMALL\n",
-      "metadata: \"{\\\"parameters\\\":{\\\"input_width\\\":1,\\\"label_width\\\":1,\\\"hidden_size\\\":17,\\\"num_qubits\\\":8,\\\"depth\\\":7,\\\"dropout_coef\\\":0.24,\\\"nqlayers\\\":3},\\\"inputs\\\":{\\\"model\\\":{\\\"storage_id\\\":\\\"MODEL_BUCKET_STORAGE_ID\\\"},\\\"data\\\":{\\\"storage_id\\\":\\\"DATA_BUCKET_STORAGE_ID\\\"}}}\"\n",
-      "result {\n",
-      "}\n",
-      "created_by: \"35dc8cba-b06d-4f15-b9bc-588f608789de\"\n",
-      "created_at {\n",
-      "  seconds: 1705664558\n",
-      "  nanos: 249253227\n",
-      "}\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "with TQ42Client() as client:\n",
     "    run = ExperimentRun.create(\n",
@@ -282,7 +234,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.18"
+   "version": "3.11.6"
   }
  },
  "nbformat": 4,

--- a/notebooks/ts_hqmlp_example.ipynb
+++ b/notebooks/ts_hqmlp_example.ipynb
@@ -12,7 +12,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": null,
    "id": "bf7c0de1-c5e4-46eb-a0d1-dbe6eb8585e0",
    "metadata": {},
    "outputs": [],
@@ -52,34 +52,28 @@
   },
   {
    "cell_type": "code",
+   "execution_count": null,
+   "id": "a0b81d17d8f0bc59",
+   "metadata": {
+    "collapsed": false,
+    "jupyter": {
+     "outputs_hidden": false
+    }
+   },
    "outputs": [],
    "source": [
     "with TQ42Client() as client:\n",
     "    org_sample = list_all_organizations(client=client)[0] \n",
     "    proj_sample = list_all_projects(client=client, organization_id=org_sample.id)[0]\n",
     "    exp_sample = list_all_experiments(client=client, project_id=proj_sample.id)[-1]"
-   ],
-   "metadata": {
-    "collapsed": false
-   },
-   "id": "a0b81d17d8f0bc59"
+   ]
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": null,
    "id": "1e2c2381-bed3-4e2b-9e00-48db34e49a95",
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "<tq42.project.Project object at 0x1096bddc0>\n",
-      "<tq42.organization.Organization object at 0x1096bdc40>\n",
-      "<tq42.experiment.Experiment object at 0x1096bdbe0>\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "    print(f\"Running experiment within: Org {org_sample.id}, Proj {proj_sample.id} and Exp {exp_sample.id}`\")"
    ]
@@ -94,7 +88,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": null,
    "id": "4d3acb6a-33a0-4cf4-b9bc-ecb038960f7d",
    "metadata": {},
    "outputs": [],
@@ -140,31 +134,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": null,
    "id": "169fadb5-49f6-4f5b-97a6-3268db5b78c3",
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "id: \"544cbfac-feb8-4179-901f-8b47dde9b5c0\"\n",
-      "experiment_id: \"811fd59b-2b51-42ea-b573-b5aebb0d5d7a\"\n",
-      "sequential_id: 38\n",
-      "status: QUEUED\n",
-      "algorithm: TS_HQMLP_TRAIN\n",
-      "hardware: SMALL\n",
-      "metadata: \"{\\\"parameters\\\":{\\\"input_width\\\":1,\\\"label_width\\\":1,\\\"hidden_size\\\":17,\\\"num_qubits\\\":8,\\\"depth\\\":7,\\\"measurement_mode\\\":\\\"NONE\\\",\\\"rotation\\\":\\\"X\\\",\\\"entangling\\\":\\\"BASIC\\\",\\\"measure\\\":\\\"Z\\\",\\\"diff_method\\\":\\\"ADJOINT\\\",\\\"qubit_type\\\":\\\"LIGHTNING_QUBIT\\\",\\\"act_func\\\":\\\"SIGMOID\\\",\\\"dropout\\\":false,\\\"dropout_p\\\":0.2,\\\"bn\\\":false,\\\"num_epochs\\\":5,\\\"batch_size\\\":20,\\\"learning_rate\\\":0.05,\\\"optim\\\":\\\"ADAM\\\",\\\"loss_func\\\":\\\"MSE\\\",\\\"train_model_info\\\":null},\\\"inputs\\\":{\\\"data\\\":{\\\"storage_id\\\":\\\"1fcc5e6c-b962-410b-a257-739f7172db03\\\"}}}\"\n",
-      "result {\n",
-      "}\n",
-      "created_by: \"35dc8cba-b06d-4f15-b9bc-588f608789de\"\n",
-      "created_at {\n",
-      "  seconds: 1705664885\n",
-      "  nanos: 342501208\n",
-      "}\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "    run = ExperimentRun.create(\n",
     "        client=client,\n",
@@ -187,7 +160,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": null,
    "id": "417ae287-2af1-41e2-bb3e-cc4c17d2410c",
    "metadata": {},
    "outputs": [],
@@ -209,7 +182,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": null,
    "id": "c2565e58-b31b-4b32-8fc7-b33953c6787f",
    "metadata": {},
    "outputs": [],
@@ -250,31 +223,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": null,
    "id": "e84543c0-2810-401b-a865-53a764876981",
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "id: \"0b0900fb-3713-47d7-9802-60ac80d1f71b\"\n",
-      "experiment_id: \"811fd59b-2b51-42ea-b573-b5aebb0d5d7a\"\n",
-      "sequential_id: 39\n",
-      "status: QUEUED\n",
-      "algorithm: TS_HQMLP_EVAL\n",
-      "hardware: SMALL\n",
-      "metadata: \"{\\\"parameters\\\":{\\\"input_width\\\":1,\\\"label_width\\\":1,\\\"hidden_size\\\":17,\\\"num_qubits\\\":8,\\\"depth\\\":7,\\\"measurement_mode\\\":\\\"NONE\\\",\\\"rotation\\\":\\\"X\\\",\\\"entangling\\\":\\\"BASIC\\\",\\\"measure\\\":\\\"Z\\\",\\\"diff_method\\\":\\\"ADJOINT\\\",\\\"qubit_type\\\":\\\"LIGHTNING_QUBIT\\\",\\\"act_func\\\":\\\"SIGMOID\\\",\\\"dropout\\\":false,\\\"dropout_p\\\":0.2,\\\"bn\\\":false},\\\"inputs\\\":{\\\"model\\\":{\\\"storage_id\\\":\\\"MODEL_BUCKET_STORAGE_ID\\\"},\\\"data\\\":{\\\"storage_id\\\":\\\"DATA_BUCKET_STORAGE_ID\\\"}}}\"\n",
-      "result {\n",
-      "}\n",
-      "created_by: \"35dc8cba-b06d-4f15-b9bc-588f608789de\"\n",
-      "created_at {\n",
-      "  seconds: 1705664891\n",
-      "  nanos: 31514947\n",
-      "}\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "with TQ42Client() as client:\n",
     "    run = ExperimentRun.create(\n",
@@ -304,7 +256,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.18"
+   "version": "3.11.6"
   }
  },
  "nbformat": 4,

--- a/notebooks/ts_lstm_example.ipynb
+++ b/notebooks/ts_lstm_example.ipynb
@@ -12,7 +12,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 23,
+   "execution_count": null,
    "id": "bf7c0de1-c5e4-46eb-a0d1-dbe6eb8585e0",
    "metadata": {},
    "outputs": [],
@@ -45,20 +45,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 24,
+   "execution_count": null,
    "id": "1e2c2381-bed3-4e2b-9e00-48db34e49a95",
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "<tq42.project.Project object at 0x10f7dda60>\n",
-      "<tq42.organization.Organization object at 0x10f7f57f0>\n",
-      "<tq42.experiment.Experiment object at 0x10cf00ac0>\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "with TQ42Client() as client:\n",
     "    org_sample = list_all_organizations(client=client)[0] \n",
@@ -68,14 +58,18 @@
   },
   {
    "cell_type": "code",
+   "execution_count": null,
+   "id": "423e8fe8e2c6b591",
+   "metadata": {
+    "collapsed": false,
+    "jupyter": {
+     "outputs_hidden": false
+    }
+   },
    "outputs": [],
    "source": [
     "    print(f\"Running experiment within: Org {org_sample.id}, Proj {proj_sample.id} and Exp {exp_sample.id}`\")"
-   ],
-   "metadata": {
-    "collapsed": false
-   },
-   "id": "423e8fe8e2c6b591"
+   ]
   },
   {
    "cell_type": "markdown",
@@ -87,7 +81,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 25,
+   "execution_count": null,
    "id": "4d3acb6a-33a0-4cf4-b9bc-ecb038960f7d",
    "metadata": {},
    "outputs": [],
@@ -122,31 +116,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 26,
+   "execution_count": null,
    "id": "169fadb5-49f6-4f5b-97a6-3268db5b78c3",
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "id: \"e4724c5b-414d-4c31-9181-b0b7aaaab9ef\"\n",
-      "experiment_id: \"811fd59b-2b51-42ea-b573-b5aebb0d5d7a\"\n",
-      "sequential_id: 13\n",
-      "status: QUEUED\n",
-      "algorithm: TS_LSTM_TRAIN\n",
-      "hardware: SMALL\n",
-      "metadata: \"{\\\"parameters\\\":{\\\"input_width\\\":24,\\\"label_width\\\":1,\\\"hidden_size\\\":17,\\\"dropout_coef\\\":0.17,\\\"num_epochs\\\":20,\\\"batch_size\\\":128,\\\"learning_rate\\\":0.001,\\\"optim\\\":\\\"ADAM\\\",\\\"loss_func\\\":\\\"MAE\\\",\\\"train_model_info\\\":null},\\\"inputs\\\":{\\\"data\\\":{\\\"storage_id\\\":\\\"fc4310c5-a2a3-43cd-990c-8dd2b1aec994\\\"}}}\"\n",
-      "result {\n",
-      "}\n",
-      "created_by: \"35dc8cba-b06d-4f15-b9bc-588f608789de\"\n",
-      "created_at {\n",
-      "  seconds: 1705660472\n",
-      "  nanos: 338705048\n",
-      "}\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "    run = ExperimentRun.create(\n",
     "        client=client,\n",
@@ -169,7 +142,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 27,
+   "execution_count": null,
    "id": "417ae287-2af1-41e2-bb3e-cc4c17d2410c",
    "metadata": {},
    "outputs": [],
@@ -192,7 +165,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 28,
+   "execution_count": null,
    "id": "c2565e58-b31b-4b32-8fc7-b33953c6787f",
    "metadata": {},
    "outputs": [],
@@ -222,31 +195,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 29,
+   "execution_count": null,
    "id": "e84543c0-2810-401b-a865-53a764876981",
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "id: \"ff12f5d8-ee02-4438-a138-ec4969d2d361\"\n",
-      "experiment_id: \"811fd59b-2b51-42ea-b573-b5aebb0d5d7a\"\n",
-      "sequential_id: 14\n",
-      "status: QUEUED\n",
-      "algorithm: TS_LSTM_EVAL\n",
-      "hardware: SMALL\n",
-      "metadata: \"{\\\"parameters\\\":{\\\"input_width\\\":1,\\\"label_width\\\":1,\\\"hidden_size\\\":17,\\\"dropout_coef\\\":0.24},\\\"inputs\\\":{\\\"model\\\":{\\\"storage_id\\\":\\\"MODEL_BUCKET_STORAGE_ID\\\"},\\\"data\\\":{\\\"storage_id\\\":\\\"DATA_BUCKET_STORAGE_ID\\\"}}}\"\n",
-      "result {\n",
-      "}\n",
-      "created_by: \"35dc8cba-b06d-4f15-b9bc-588f608789de\"\n",
-      "created_at {\n",
-      "  seconds: 1705660479\n",
-      "  nanos: 305211590\n",
-      "}\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "with TQ42Client() as client:\n",
     "    run = ExperimentRun.create(\n",
@@ -276,7 +228,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.18"
+   "version": "3.11.6"
   }
  },
  "nbformat": 4,

--- a/notebooks/ts_mlp_example.ipynb
+++ b/notebooks/ts_mlp_example.ipynb
@@ -12,7 +12,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": null,
    "id": "bf7c0de1-c5e4-46eb-a0d1-dbe6eb8585e0",
    "metadata": {},
    "outputs": [],
@@ -46,20 +46,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": null,
    "id": "1e2c2381-bed3-4e2b-9e00-48db34e49a95",
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "<tq42.project.Project object at 0x111b506d0>\n",
-      "<tq42.organization.Organization object at 0x111b9d610>\n",
-      "<tq42.experiment.Experiment object at 0x1119d6d00>\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "with TQ42Client() as client:\n",
     "    org_sample = list_all_organizations(client=client)[0] \n",
@@ -69,14 +59,18 @@
   },
   {
    "cell_type": "code",
+   "execution_count": null,
+   "id": "15323ae117dd0852",
+   "metadata": {
+    "collapsed": false,
+    "jupyter": {
+     "outputs_hidden": false
+    }
+   },
    "outputs": [],
    "source": [
     "    print(f\"Running experiment within: Org {org_sample.id}, Proj {proj_sample.id} and Exp {exp_sample.id}`\")"
-   ],
-   "metadata": {
-    "collapsed": false
-   },
-   "id": "15323ae117dd0852"
+   ]
   },
   {
    "cell_type": "markdown",
@@ -88,7 +82,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": null,
    "id": "4d3acb6a-33a0-4cf4-b9bc-ecb038960f7d",
    "metadata": {},
    "outputs": [],
@@ -126,31 +120,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": null,
    "id": "169fadb5-49f6-4f5b-97a6-3268db5b78c3",
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "id: \"52516153-2f8e-4da3-8cc1-04e075a6aeb1\"\n",
-      "experiment_id: \"811fd59b-2b51-42ea-b573-b5aebb0d5d7a\"\n",
-      "sequential_id: 17\n",
-      "status: QUEUED\n",
-      "algorithm: TS_MLP_TRAIN\n",
-      "hardware: SMALL\n",
-      "metadata: \"{\\\"parameters\\\":{\\\"input_width\\\":1,\\\"label_width\\\":1,\\\"dim_list\\\":[30,45,60],\\\"act_func\\\":\\\"SIGMOID\\\",\\\"dropout\\\":true,\\\"dropout_p\\\":0.5,\\\"bn\\\":true,\\\"num_epochs\\\":5,\\\"batch_size\\\":20,\\\"learning_rate\\\":0.05,\\\"optim\\\":\\\"ADAM\\\",\\\"loss_func\\\":\\\"MSE\\\",\\\"train_model_info\\\":null},\\\"inputs\\\":{\\\"data\\\":{\\\"storage_id\\\":\\\"1fcc5e6c-b962-410b-a257-739f7172db03\\\"}}}\"\n",
-      "result {\n",
-      "}\n",
-      "created_by: \"35dc8cba-b06d-4f15-b9bc-588f608789de\"\n",
-      "created_at {\n",
-      "  seconds: 1705663712\n",
-      "  nanos: 542225914\n",
-      "}\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "    run = ExperimentRun.create(\n",
     "        client=client,\n",
@@ -173,7 +146,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": null,
    "id": "417ae287-2af1-41e2-bb3e-cc4c17d2410c",
    "metadata": {},
    "outputs": [],
@@ -196,7 +169,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
+   "execution_count": null,
    "id": "c2565e58-b31b-4b32-8fc7-b33953c6787f",
    "metadata": {},
    "outputs": [],
@@ -229,31 +202,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 18,
+   "execution_count": null,
    "id": "e84543c0-2810-401b-a865-53a764876981",
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "id: \"501e8bb5-428f-4461-9bf3-6f836af57916\"\n",
-      "experiment_id: \"811fd59b-2b51-42ea-b573-b5aebb0d5d7a\"\n",
-      "sequential_id: 18\n",
-      "status: QUEUED\n",
-      "algorithm: TS_MLP_EVAL\n",
-      "hardware: SMALL\n",
-      "metadata: \"{\\\"parameters\\\":{\\\"input_width\\\":1,\\\"label_width\\\":1,\\\"dim_list\\\":[30,45,60],\\\"act_func\\\":\\\"SIGMOID\\\",\\\"dropout\\\":true,\\\"dropout_p\\\":0.5,\\\"bn\\\":true},\\\"inputs\\\":{\\\"model\\\":{\\\"storage_id\\\":\\\"MODEL_STORAGE_BUCKET_ID\\\"},\\\"data\\\":null}}\"\n",
-      "result {\n",
-      "}\n",
-      "created_by: \"35dc8cba-b06d-4f15-b9bc-588f608789de\"\n",
-      "created_at {\n",
-      "  seconds: 1705663717\n",
-      "  nanos: 709899103\n",
-      "}\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "with TQ42Client() as client:\n",
     "    run = ExperimentRun.create(\n",
@@ -283,7 +235,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.18"
+   "version": "3.11.6"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
These notebooks were pushed to git in a corrupted state. Most likely they were last opened with a 3rd party tool like VS code or pycharm. Solution was to open them natively with Jupyter, clear all the cell outputs and re-save.