### PR TITLE
1448 error handling missing organization, project or experiment ID

### DIFF
--- a/tq42/experiment.py
+++ b/tq42/experiment.py
@@ -112,9 +112,17 @@ def list_all(client: TQ42Client, project_id: Optional[str] = None) -> List[Exper
         project_id = get_current_value("proj")
 
     list_experiments_request = ListExperimentsRequest(project_id=project_id)
-    res: ListExperimentsResponse = client.experiment_client.ListExperiments(
-        request=list_experiments_request, metadata=client.metadata
-    )
+
+    try:
+        res: ListExperimentsResponse = client.experiment_client.ListExperiments(
+            request=list_experiments_request, metadata=client.metadata
+        )
+
+    except Exception as ex:
+        if ex.args[0].code.name == "INVALID_ARGUMENT":
+            print(f"ERROR {ex.args[0].code.name }: project ID '{project_id}' not found")
+            return list()
+
     return [
         Experiment.from_proto(client=client, msg=experiment_run)
         for experiment_run in res.experiments

--- a/tq42/experiment_run.py
+++ b/tq42/experiment_run.py
@@ -166,10 +166,19 @@ def list_all(client: TQ42Client, experiment_id: str) -> List[ExperimentRun]:
     https://terra-quantum-tq42sdk-docs.readthedocs-hosted.com/en/latest/Python_Developer_Guide/Setting_Up_Your_Environment.html#list-all-runs-within-an-experiment
     """
     list_exp_run_request = ListExperimentRunsRequest(experiment_id=experiment_id)
+    try:
+        res: ListExperimentRunsResponse = (
+            client.experiment_run_client.ListExperimentRuns(
+                request=list_exp_run_request, metadata=client.metadata
+            )
+        )
+    except Exception as ex:
+        if ex.args[0].code.name == "INVALID_ARGUMENT":
+            print(
+                f"ERROR {ex.args[0].code.name }: experiment ID '{experiment_id}' not found"
+            )
+            return list()
 
-    res: ListExperimentRunsResponse = client.experiment_run_client.ListExperimentRuns(
-        request=list_exp_run_request, metadata=client.metadata
-    )
     # TODO: It seems like currently the API returns `experiment_runs` instead of `experimentRuns` as in the protobufs
     return [
         ExperimentRun.from_proto(client=client, msg=experiment_run)

--- a/tq42/project.py
+++ b/tq42/project.py
@@ -169,8 +169,14 @@ def list_all(
         organization_id = get_current_value("org")
 
     create_list_proj_request = ListProjectsRequest(organization_id=organization_id)
-
-    res: ListProjectsResponse = client.project_client.ListProjects(
-        request=create_list_proj_request, metadata=client.metadata
-    )
+    try:
+        res: ListProjectsResponse = client.project_client.ListProjects(
+            request=create_list_proj_request, metadata=client.metadata
+        )
+    except Exception as ex:
+        if ex.args[0].code.name == "INVALID_ARGUMENT":
+            print(
+                f"ERROR {ex.args[0].code.name }: organization ID '{organization_id}' not found"
+            )
+            return list()
     return [Project.from_proto(client=client, msg=data) for data in res.projects]


### PR DESCRIPTION
[tq42-1448](https://terraquantum.atlassian.net/browse/TQ42-1448) points out that in case we use an invalid organization ID for listing the existing projects no error message is spawned and the script crashes.

That happened also when we want to list the organisation and the experiment (see [here](https://terra-quantum-tq42sdk-docs.readthedocs-hosted.com/en/latest/Python_Developer_Guide/Setting_Up_Your_Environment.html#list-all-projects))

Now for all these cases an empty list is returned and an error message is shown

The case when we want to list the datasets but we provide to the function an invalid project_id is non managed because the error is another type of internal error (i.e.: `PERMISSION_DENIED`  instead of `INVALID_ARGUMENT`) and we should face it in another ticket/PR