### PR TITLE
Tq42 1458 setting up your environment setting friendly names automatically return of it is not displayed

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ include = ["utils/text_files/*.txt", "utils/text_files/config.json", "tests/test
 
 [tool.poetry]
 name = "tq42"
-version = "0.5.22"
+version = "0.5.23"
 description = "tq42 sdk"
 readme = "README.md"
 authors = ["Terra Quantum AG"]

--- a/tq42/experiment.py
+++ b/tq42/experiment.py
@@ -97,7 +97,11 @@ class Experiment:
 
         For details, see https://terra-quantum-tq42sdk-docs.readthedocs-hosted.com/en/latest/Python_Developer_Guide/Setting_Up_Your_Environment.html#setting-friendly-names-for-projects-and-experiments
         """
-        return self.update(name=friendly_name)
+        self.update(name=friendly_name)
+        print(
+            f"Set the friendly name '{friendly_name}' for the experiment id '{self.id}'"
+        )
+        return self
 
 
 @handle_generic_sdk_errors

--- a/tq42/project.py
+++ b/tq42/project.py
@@ -109,7 +109,11 @@ class Project:
         For details, see
         https://terra-quantum-tq42sdk-docs.readthedocs-hosted.com/en/latest/Python_Developer_Guide/Setting_Up_Your_Environment.html#setting-friendly-names-for-projects-and-experiments
         """
-        return self.update(name=friendly_name)
+        self.update(name=friendly_name)
+        print(
+            f"Set the friendly name '{ friendly_name   }' for the project id '{ self.id   }'"
+        )
+        return self
 
     @staticmethod
     @handle_generic_sdk_errors

--- a/tq42/project.py
+++ b/tq42/project.py
@@ -110,9 +110,7 @@ class Project:
         https://terra-quantum-tq42sdk-docs.readthedocs-hosted.com/en/latest/Python_Developer_Guide/Setting_Up_Your_Environment.html#setting-friendly-names-for-projects-and-experiments
         """
         self.update(name=friendly_name)
-        print(
-            f"Set the friendly name '{ friendly_name   }' for the project id '{ self.id   }'"
-        )
+        print(f"Set the friendly name '{friendly_name}' for the project id '{self.id}'")
         return self
 
     @staticmethod


### PR DESCRIPTION
https://terraquantum.atlassian.net/browse/TQ42-1458



After setting a[ friendly name](https://terra-quantum-tq42sdk-docs.readthedocs-hosted.com/en/latest/Python_Developer_Guide/Setting_Up_Your_Environment.html#setting-friendly-names-for-projects-and-experiments) for a project or an experiment the system does not notify it.

Now it ll print out this information.

For example:
`Project(client=client, id="347826c3-5b62-4bd7-ad06-cfd11b9e4746").set_friendly_name(friendly_name="Fleet Routing")`

will not print out:
`Set the friendly name 'Fleet Routing' for the project id '347826c3-5b62-4bd7-ad06-cfd11b9e4746'`