### PR TITLE
TQ42-1508 remove error message section with broken link.

### DIFF
--- a/tq42/utils/text_files/unauthenticated_error.txt
+++ b/tq42/utils/text_files/unauthenticated_error.txt
@@ -1,5 +1,4 @@
 User Not Logged In: Authentication Required
 You are not currently logged in. Please log in or authenticate to access this feature or command.
 To log in with your username and password or stored token, type the command: tq42 auth login
-If you don't have an account, sign up by visiting our website at tq42.com/signup.
 If you need further assistance, please contact our support team at support@terraquantum.swiss.


### PR DESCRIPTION
Per the ticket, the part of the error message with the broken link was removed. 