### PR TITLE
TQ42-1531 fixed 404 error

### DIFF
--- a/docs/source/CLI_Developer_Guide/Errors.md
+++ b/docs/source/CLI_Developer_Guide/Errors.md
@@ -61,7 +61,7 @@ Suggestions:
 Unable to Execute: `[command]`
 
 We were unable to find the default org and/or proj ID required to run this command.
-For a list of available commands, type `tq42 --help` or consult the documentation at tq42.com/help.
+For a list of available commands, type `tq42 --help` or consult the documentation at [TQ42 Help](https://terra-quantum-tq42sdk-docs.readthedocs-hosted.com/en/latest/).
 
 ## Invalid Argument
 

--- a/docs/source/Python_Developer_Guide/Errors.md
+++ b/docs/source/Python_Developer_Guide/Errors.md
@@ -61,7 +61,7 @@ Suggestions:
 Unable to Execute: `[command]`
 
 We were unable to find the default org and/or proj ID required to run this command.
-For a list of available commands, type `tq42 --help` or consult the documentation at tq42.com/help.
+For a list of available commands, type `tq42 --help` or consult the documentation at [TQ42 Help](https://terra-quantum-tq42sdk-docs.readthedocs-hosted.com/en/latest/).
 
 ## Invalid Argument
 


### PR DESCRIPTION
In the  https://terra-quantum-tq42sdk-docs.readthedocs-hosted.com/en/latest/CLI_Developer_Guide/Errors.html#no-default
the 'tq42.com/help' link does not exist.
Replaced with https://terra-quantum-tq42sdk-docs.readthedocs-hosted.com/en/latest/