### PR TITLE
Print org, proj, exp names in basic_example.ipynb

### DIFF
--- a/notebooks/basic_example.ipynb
+++ b/notebooks/basic_example.ipynb
@@ -58,7 +58,7 @@
     "with TQ42Client() as client: \n",
     "    org_list = list_all_organizations(client=client)\n",
     "    org = org_list[0]\n",
-    "    print(org.id)"
+    "    print(org.data.name, org.id)"
    ]
   },
   {
@@ -83,7 +83,7 @@
    "source": [
     "    proj_list = list_all_projects(client=client, organization_id=org.id)\n",
     "    proj = proj_list[0]\n",
-    "    print(proj.id)"
+    "    print(proj.data.name, proj.id)"
    ]
   },
   {
@@ -109,7 +109,7 @@
    "source": [
     "    exp_list = list_all_experiments(client=client, project_id=proj.id)\n",
     "    exp_sample = exp_list[-1]\n",
-    "    print(exp_sample.id)"
+    "    print(exp_sample.data.name, exp_sample.id)"
    ]
   },
   {
@@ -134,7 +134,7 @@
    },
    "outputs": [],
    "source": [
-    "    print(f\"Running experiment within: Org {org.id}, Proj {proj.id} and Exp {exp_sample.id}`\")"
+    "    print(f\"Running experiment within: Org {org.data.name, org.id}, Proj {proj.data.name, proj.id} and Exp {exp_sample.data.name, exp_sample.id}`\")"
    ]
   },
   {


### PR DESCRIPTION
In addition to printing the IDs of the org, project, and exp_sample, I added the code to print the names of each next to the IDs so it's easier to reference for the user.