### PR TITLE
fix: install at least a valid sphinx rtd theme version

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -3,3 +3,4 @@ renku-sphinx-theme
 recommonmark
 sphinx_markdown_tables
 sphinx_copybutton
+sphinx-rtd-theme>=1.3.0


### PR DESCRIPTION
new run:
![Bildschirmfoto 2024-07-23 um 15 42 02](https://github.com/user-attachments/assets/be812335-780b-4400-985f-9e915ab7ef39)
old run:
![Bildschirmfoto 2024-07-23 um 15 41 59](https://github.com/user-attachments/assets/a8adf40c-095e-4725-b8a4-d93054f6291a)

somehow a more recent pipeline run for building the docs used an older version of the theme 🤔 
Maybe related to a new version where they downgraded the minimum valid theme version, not sure.
Fixed it by requiring at least a specific theme version. 
