### PR TITLE
TQ42-1892: Improve functionality for accessing experiment results 

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ include = ["utils/text_files/*.txt", "utils/text_files/config.json", "tests/test
 
 [tool.poetry]
 name = "tq42"
-version = "0.9.0"
+version = "0.9.1"
 description = "tq42 sdk"
 readme = "README.md"
 authors = ["Terra Quantum AG"]

--- a/tq42/cli/utils/cli_functions.py
+++ b/tq42/cli/utils/cli_functions.py
@@ -43,9 +43,7 @@ def list_proj_by_org(client: TQ42Client, org: str) -> str:
 
 
 def get_exprun(client: TQ42Client, run_id: str) -> str:
-    result = run_formatter.run_checked_lines(
-        ExperimentRun(client=client, id=run_id).data
-    )
+    result = run_formatter.run_checked_lines(ExperimentRun(client=client, id=run_id))
     result = "\n".join(result)
     return result
 
@@ -96,7 +94,7 @@ def proj_show(client: TQ42Client) -> str:
 def poll_exprun(client: TQ42Client, run_id: str) -> str:
     try:
         result = ExperimentRun(client=client, id=run_id).poll()
-        result = run_formatter.run_checked_lines(result.data)
+        result = run_formatter.run_checked_lines(result)
         result = "\n".join(result)
         return result
 

--- a/tq42/experiment_run.py
+++ b/tq42/experiment_run.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import json
 import time
-from typing import Optional, List, Mapping, Any
+from typing import Optional, List, Mapping, Any, Union
 
 from com.terraquantum.experiment.v1.experimentrun.experiment_run_pb2 import (
     ExperimentRunStatusProto,
@@ -94,9 +94,9 @@ class ExperimentRun:
         if not self.completed:
             return None
 
-        result: dict[str, Any] | str = MessageToDict(self.data.result.outcome).get(
-            "result", {}
-        )
+        result: Union[dict[str, Any], str] = MessageToDict(
+            self.data.result.outcome
+        ).get("result", {})
         if isinstance(result, str):
             return json.loads(result)
         elif "results_string" in result:


### PR DESCRIPTION
Added two new properties to `ExperimentRun`:

- `result`: access the `outcome.result` field. Automatically parses the field from json if either `outcome.result` is a `str` or `outcome.result.results_string` is present.
- `outputs`: access the `outcome.outputs` field.

Both properties return `None` if the experiment run is not completed.

### SDK

```python

run = ExperimentRun(....)

# if status is not completed
run.result # returns None
run.outputs # returns None

# if status is completed
run.result # returns a dict of results, e.g. {'version': '0.1.0', 'y': [0.0], 'msg': 'right'}
run.outputs # returns the outputs as dict, e.g. {'circuit': {'storage_id': '<id>'}}
```

### CLI

The CLI output for a completed run will now look like this:
```bash
run="ffa96868-7a97-42f2-9cc1-5daa3aba7d80"
status="COMPLETED"
algorithm="CVA_OPT"
compute="SMALL"
result="{"result": {"x1": [0.1001131336435195], "x2": [0.10178380543679133], "Ackley": [0.5212156176567078]}}"
outputs="{}"
```

and for a failed run like this:
```bash
run="870de378-3a6a-4df1-b516-fb4b99dc1154"
status="FAILED"
algorithm="TOY"
compute="SMALL"
result="ERROR"
error_message="{"error": "That's wrong!"}"
```