### PR TITLE
fix: only show result and outputs lines if the run is completed

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ include = ["utils/text_files/*.txt", "utils/text_files/config.json", "tests/test
 
 [tool.poetry]
 name = "tq42"
-version = "0.9.1"
+version = "0.9.2"
 description = "tq42 sdk"
 readme = "README.md"
 authors = ["Terra Quantum AG"]

--- a/tq42/cli/utils/formatter.py
+++ b/tq42/cli/utils/formatter.py
@@ -86,12 +86,10 @@ class ExpRunFormatter(ItemWithIDFormatter):
         algo_line = 'algorithm="{}"'.format(data.algorithm)
         compute_line = 'compute="{}"'.format(HardwareProto.Name(data.hardware))
 
-        result_line = 'result="ERROR"'
-        if data.status == ExperimentRunStatusProto.COMPLETED:
-            result_line = f'result="{json.dumps(run.result)}"'
-
+        result_line = ""
         outputs_line = ""
         if data.status == ExperimentRunStatusProto.COMPLETED:
+            result_line = f'result="{json.dumps(run.result)}"'
             outputs_line = f'outputs="{json.dumps(run.outputs)}"'
 
         error_message = (

--- a/tq42/tests/cli/utils/test_output_format.py
+++ b/tq42/tests/cli/utils/test_output_format.py
@@ -146,7 +146,6 @@ class TestOutputFormat(unittest.TestCase):
         exp_run_data.status = 1
         exp_run_data.algorithm = "TOY"
         exp_run_data.hardware = 6
-        exp_run_data.result = "ERROR"
         exp_run_data.error_message = ""
         exp_run = ExperimentRun(client=None, id="RUN_ID", data=exp_run_data)
 
@@ -155,7 +154,6 @@ class TestOutputFormat(unittest.TestCase):
             'status="QUEUED"',
             'algorithm="TOY"',
             'compute="LARGE_GPU"',
-            'result="ERROR"',
         ]
         actual = formatter.run_formatter.run_checked_lines(exp_run)
         self.assertEqual(expected, actual)
@@ -203,8 +201,26 @@ class TestOutputFormat(unittest.TestCase):
             'status="FAILED"',
             'algorithm="TOY"',
             'compute="LARGE"',
-            'result="ERROR"',
             'error_message="error message"',
+        ]
+        actual = formatter.run_formatter.run_checked_lines(exp_run)
+        self.assertEqual(expected, actual)
+
+    def test_exp_run_checked_lines_not_done(self):
+        data = ExperimentRunProto(
+            id="RUN_ID",
+            experiment_id="exp_id",
+            algorithm="TOY",
+            status=ExperimentRunStatusProto.RUNNING,
+            hardware=HardwareProto.LARGE,
+        )
+        exp_run = ExperimentRun(client=cast(TQ42Client, None), id="RUN_ID", data=data)
+
+        expected = [
+            'run="RUN_ID"',
+            'status="RUNNING"',
+            'algorithm="TOY"',
+            'compute="LARGE"',
         ]
         actual = formatter.run_formatter.run_checked_lines(exp_run)
         self.assertEqual(expected, actual)


### PR DESCRIPTION
Previously the cli output for a running experiment run showed `result="ERROR"` which is not correct. Now we only show the result if there is actually one.