### PR TITLE
TQ42-1866: add command to easily generate completion snippets

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ include = ["utils/text_files/*.txt", "utils/text_files/config.json", "tests/test
 
 [tool.poetry]
 name = "tq42"
-version = "0.9.3"
+version = "0.9.4"
 description = "tq42 sdk"
 readme = "README.md"
 authors = ["Terra Quantum AG"]

--- a/tq42/cli/completion.py
+++ b/tq42/cli/completion.py
@@ -1,0 +1,47 @@
+import sys
+from typing import Literal
+
+import click
+import click.shell_completion
+
+
+@click.command("completion")
+@click.argument("shell", required=True, type=click.Choice(["bash", "zsh", "fish"]))
+def generate_completion(shell: Literal["bash", "zsh", "fish"]) -> None:
+    """
+    Generate completion scripts for your shell.
+    Supported shells are:
+    - bash
+    - zsh
+    - fish
+
+    To load completions:
+        Bash:
+            source <(tq42 completion bash)
+        Zsh:
+            source <(tq42 completion zsh)
+        Fish:
+            tq42 completion fish | source
+    """
+
+    context = click.get_current_context()
+
+    shells = {
+        "bash": click.shell_completion.BashComplete,
+        "zsh": click.shell_completion.ZshComplete,
+        "fish": click.shell_completion.FishComplete,
+    }
+
+    shell_class = shells[shell]
+    if not shell_class:
+        raise ValueError(f"Shell {shell} is not supported.")
+
+    complete_var = f"_{context.parent.info_name.upper()}_COMPLETE"
+    sys.stdout.write(
+        shell_class(
+            cli=context.command,
+            prog_name=context.parent.info_name,
+            ctx_args={},
+            complete_var=complete_var,
+        ).source()
+    )

--- a/tq42/cli/entrypoint.py
+++ b/tq42/cli/entrypoint.py
@@ -1,5 +1,6 @@
 import click
 
+from tq42.cli.completion import generate_completion
 from tq42.cli.utils.types import TQ42CliContext, TQ42CliObject
 from tq42.client import TQ42Client
 from .auth_group import auth_group
@@ -44,6 +45,7 @@ cli.add_command(organization_group)
 cli.add_command(experiment_group)
 cli.add_command(project_group)
 cli.add_command(environment_group)
+cli.add_command(generate_completion)
 
 
 if __name__ == "__main__":

--- a/tq42/internal/functionality.py
+++ b/tq42/internal/functionality.py
@@ -4,7 +4,7 @@ from google.protobuf import empty_pb2
 
 from com.terraquantum.plan.v1.plan.check_functionality_request_pb2 import (
     CheckFunctionalityRequest,
-    FunctionalityProto
+    FunctionalityProto,
 )
 
 from typing import TYPE_CHECKING
@@ -20,16 +20,15 @@ class Functionality:
     """
 
     @staticmethod
-    def check(client: TQ42Client, organization_id: str, functionality_type: str, version: str) -> None:
+    def check(
+        client: TQ42Client, organization_id: str, functionality_type: str, version: str
+    ) -> None:
         """
         Checks if a functionality with given version should be accessible for the given organization.
         """
         req = CheckFunctionalityRequest(
             organization_id=organization_id,
-            functionality=FunctionalityProto(
-                type=functionality_type,
-                version=version
-            )
+            functionality=FunctionalityProto(type=functionality_type, version=version),
         )
         res: empty_pb2.Empty = client.plan_client.CheckFunctionality(
             request=req, metadata=client.metadata


### PR DESCRIPTION
It's actually a convention across clis to have the completion available at `<name> completion [zsh|bash|fish]`, see kubectl etc.

