### PR TITLE
TQ42-623: allow specifying environment through env vars

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ include = ["utils/text_files/*.txt", "utils/text_files/config.json", "tests/test
 
 [tool.poetry]
 name = "tq42"
-version = "0.9.6"
+version = "0.9.7"
 description = "tq42 sdk"
 readme = "README.md"
 authors = ["Terra Quantum AG"]

--- a/tq42/cli/entrypoint.py
+++ b/tq42/cli/entrypoint.py
@@ -1,3 +1,6 @@
+import os
+from typing import Optional
+
 import click
 
 from tq42.cli.completion import generate_completion
@@ -12,14 +15,15 @@ from .environment_group import environment_group
 
 @click.group()
 @click.option(
-    "--config",
-    "config_path",
+    "--env",
+    "environment_name",
     required=False,
-    help="Set path to alternate configuration file location",
+    default=lambda: os.environ.get("ENV", None),
+    help="Environment to use for the CLI",
 )
 @click.version_option()
 @click.pass_context
-def cli(ctx: TQ42CliContext, config_path: str):
+def cli(ctx: TQ42CliContext, environment_name: Optional[str]):
     """
     Visit https://help.terraquantum.io/ to access our help center, from where you can access help articles and video tutorials, report bugs,
     contact support and request improvements.
@@ -37,7 +41,7 @@ def cli(ctx: TQ42CliContext, config_path: str):
     All other command are optional.
     """
     ctx.ensure_object(TQ42CliObject)
-    ctx.obj.client = TQ42Client(alt_config_file=config_path)
+    ctx.obj.client = TQ42Client(environment_name=environment_name)
 
 
 cli.add_command(auth_group)

--- a/tq42/cli/entrypoint.py
+++ b/tq42/cli/entrypoint.py
@@ -1,6 +1,3 @@
-import os
-from typing import Optional
-
 import click
 
 from tq42.cli.completion import generate_completion
@@ -14,16 +11,9 @@ from .environment_group import environment_group
 
 
 @click.group()
-@click.option(
-    "--env",
-    "environment_name",
-    required=False,
-    default=lambda: os.environ.get("ENV", None),
-    help="Environment to use for the CLI",
-)
 @click.version_option()
 @click.pass_context
-def cli(ctx: TQ42CliContext, environment_name: Optional[str]):
+def cli(ctx: TQ42CliContext):
     """
     Visit https://help.terraquantum.io/ to access our help center, from where you can access help articles and video tutorials, report bugs,
     contact support and request improvements.
@@ -41,7 +31,7 @@ def cli(ctx: TQ42CliContext, environment_name: Optional[str]):
     All other command are optional.
     """
     ctx.ensure_object(TQ42CliObject)
-    ctx.obj.client = TQ42Client(environment_name=environment_name)
+    ctx.obj.client = TQ42Client()
 
 
 cli.add_command(auth_group)

--- a/tq42/client.py
+++ b/tq42/client.py
@@ -2,7 +2,6 @@ import json
 import os
 import webbrowser
 from datetime import datetime
-from typing import Optional
 
 import grpc
 from grpc import aio
@@ -77,8 +76,8 @@ class TQ42Client:
     def __exit__(self, exc_type, exc_val, exc_tb):
         pass
 
-    def __init__(self, environment_name: Optional[str] = None):
-        self._environment = ConfigEnvironment.from_env(name=environment_name)
+    def __init__(self):
+        self._environment = ConfigEnvironment.from_env()
         self._token_manager = TokenManager(self._environment)
 
         self.server_port = 443

--- a/tq42/client.py
+++ b/tq42/client.py
@@ -2,10 +2,13 @@ import json
 import os
 import webbrowser
 from datetime import datetime
+from typing import Optional
+
 import grpc
 from grpc import aio
 import requests
-from tq42.utils import dirs, file_handling, misc
+
+from tq42.utils import file_handling, misc
 from tq42.utils.token_manager import TokenManager
 from tq42.utils.exception_handling import handle_generic_sdk_errors
 import time
@@ -29,7 +32,8 @@ from com.terraquantum.channel.v1alpha1 import (
     channel_service_pb2_grpc as pb2_channel_grpc,
 )
 import com.terraquantum.plan.v1.plan.plan_service_pb2_grpc as pb2_plan_grpc
-from tq42.utils.environment import environment_default_set
+
+from tq42.utils.environment import ConfigEnvironment, environment_default_set
 from tq42.exceptions import AuthenticationError
 
 _service_config = {
@@ -53,75 +57,6 @@ _service_config = {
 }
 
 
-class _ConfigEnvironment:
-    """
-    URLs determining environment
-    """
-
-    def __init__(self, base_url, client_id, scope):
-        self.base_url = base_url
-        self.client_id = client_id
-        self.scope = scope
-
-    @property
-    def api_host(self):
-        return "api.{}".format(self.base_url)
-
-    @property
-    def channels_host(self):
-        return "channels.{}".format(self.base_url)
-
-    @property
-    def auth_url_token(self):
-        return "https://auth.{}/oauth/token".format(self.base_url)
-
-    @property
-    def auth_url_code(self):
-        return "https://auth.{}/oauth/device/code".format(self.base_url)
-
-    @property
-    def audience(self):
-        return "https://graphql-gateway.{}/graphql".format(self.base_url)
-
-    @property
-    def client_credential_flow_audience(self):
-        return "https://api.{}".format(self.base_url)
-
-    @property
-    def headers(self):
-        return {"Content-Type": "application/x-www-form-urlencoded"}
-
-    @property
-    def code_data(self):
-        return {
-            "client_id": self.client_id,
-            "scope": self.scope,
-            "audience": self.audience,
-        }
-
-    def token_data(self, device_code):
-        return {
-            "grant_type": "urn:ietf:params:oauth:grant-type:device_code",
-            "device_code": device_code,
-            "client_id": self.client_id,
-        }
-
-    def refresh_token_data(self, refresh_token):
-        return {
-            "grant_type": "refresh_token",
-            "refresh_token": refresh_token,
-            "client_id": self.client_id,
-        }
-
-    def client_credentials_data(self, client_id, client_secret, audience):
-        return {
-            "client_id": client_id,
-            "client_secret": client_secret,
-            "grant_type": "client_credentials",
-            "audience": audience,
-        }
-
-
 class TQ42Client:
     """
     Create a new instance of the TQ42Client to pass to any resource
@@ -142,39 +77,15 @@ class TQ42Client:
     def __exit__(self, exc_type, exc_val, exc_tb):
         pass
 
-    def __init__(self, alt_config_file=None):
-        # check whether "alt_config_file" is the default filepath, if it is, token.json resides
-        # in ~/.tqsdk/ and config.json inside utils/text_files/, if not using default,
-        # config.json and token.json will reside in the same path
-        # this happens when the user specifies a path during initialization of tq42 (usually for doing tests)
+    def __init__(self, environment_name: Optional[str] = None):
+        self._environment = ConfigEnvironment.from_env(name=environment_name)
+        self._token_manager = TokenManager(self._environment)
 
-        self.default_config_file = dirs.text_files_dir("config.json")
-        self.config_file = self.default_config_file
-        self.config_folder = dirs.get_config_folder_path()
-
-        if alt_config_file is not None and not self._is_config_filepath_default(
-            alt_config_file
-        ):
-            self.config_file = alt_config_file
-            self.config_folder = os.path.dirname(alt_config_file)
-
-        with open(self.config_file, encoding="utf-8") as f:
-            config_data = json.load(f)
-
-        environment = _ConfigEnvironment(
-            config_data["base_url"], config_data["client_id"], config_data["scope"]
-        )
-
-        self.token_manager = TokenManager(environment, self.config_folder)
-
-        self.environment = environment
-        self.api_host = environment.api_host
-        self.channels_host = environment.channels_host
         self.server_port = 443
 
         # instantiate a channel
-        self.api_channel = grpc.secure_channel(
-            self.api_host,
+        self._api_channel = grpc.secure_channel(
+            self._environment.api_host,
             grpc.ssl_channel_credentials(),
             options=[
                 ("grpc.max_receive_message_length", 10_000_000),
@@ -183,23 +94,21 @@ class TQ42Client:
             ],
         )
         self.channels_channel = aio.secure_channel(
-            self.channels_host, grpc.ssl_channel_credentials()
+            self._environment.channels_host, grpc.ssl_channel_credentials()
         )
 
         # bind the client and the server
         self.organization_client = pb2_org_grpc.OrganizationServiceStub(
-            self.api_channel
+            self._api_channel
         )
-        self.project_client = pb2_proj_grpc.ProjectServiceStub(self.api_channel)
-        self.experiment_client = pb2_exp_grpc.ExperimentServiceStub(self.api_channel)
-        self.storage_client = pb2_data_grpc.StorageServiceStub(self.api_channel)
+        self.project_client = pb2_proj_grpc.ProjectServiceStub(self._api_channel)
+        self.experiment_client = pb2_exp_grpc.ExperimentServiceStub(self._api_channel)
+        self.storage_client = pb2_data_grpc.StorageServiceStub(self._api_channel)
         self.experiment_run_client = pb2_exp_run_grpc.ExperimentRunServiceStub(
-            self.api_channel
+            self._api_channel
         )
-        self.plan_client = pb2_plan_grpc.PlanServiceStub(self.api_channel)
+        self.plan_client = pb2_plan_grpc.PlanServiceStub(self._api_channel)
         self.channel_client = pb2_channel_grpc.ChannelServiceStub(self.channels_channel)
-        self.credential_flow_client_id = os.getenv("TQ42_AUTH_CLIENT_ID")
-        self.credential_flow_client_secret = os.getenv("TQ42_AUTH_CLIENT_SECRET")
 
     @handle_generic_sdk_errors
     def login(self):
@@ -208,21 +117,27 @@ class TQ42Client:
 
         If the environment variables `TQ42_AUTH_CLIENT_ID` and `TQ42_AUTH_CLIENT_SECRET` are set the flow is performed without user interaction.
         """
-        if self.credential_flow_client_id and self.credential_flow_client_secret:
-            self._login_without_user_interaction()
+        credential_flow_client_id = os.getenv("TQ42_AUTH_CLIENT_ID")
+        credential_flow_client_secret = os.getenv("TQ42_AUTH_CLIENT_SECRET")
+
+        if credential_flow_client_id and credential_flow_client_secret:
+            self._login_without_user_interaction(
+                client_id=credential_flow_client_id,
+                client_secret=credential_flow_client_secret,
+            )
         else:
             self._login_with_user_interaction()
 
     @handle_generic_sdk_errors
-    def _login_without_user_interaction(self):
+    def _login_without_user_interaction(self, client_id: str, client_secret: str):
         response = requests.post(
-            self.environment.auth_url_token,
-            data=self.environment.client_credentials_data(
-                client_id=self.credential_flow_client_id,
-                client_secret=self.credential_flow_client_secret,
-                audience=self.environment.client_credential_flow_audience,
+            self._environment.auth_url_token,
+            data=self._environment.client_credentials_data(
+                client_id=client_id,
+                client_secret=client_secret,
+                audience=self._environment.client_credential_flow_audience,
             ),
-            headers=self.environment.headers,
+            headers=self._environment.headers,
         )
 
         response_json = response.json()
@@ -242,9 +157,9 @@ class TQ42Client:
         """
         # Send the POST request and print the response
         response = requests.post(
-            self.environment.auth_url_code,
-            data=self.environment.code_data,
-            headers=self.environment.headers,
+            self._environment.auth_url_code,
+            data=self._environment.code_data,
+            headers=self._environment.headers,
         )
 
         json_response = response.json()
@@ -261,14 +176,14 @@ class TQ42Client:
 
         webbrowser.open(verification_uri_complete)
 
-        data_token = self.environment.token_data(device_code)
+        data_token = self._environment.token_data(device_code)
 
         while True:
             # Send the POST request to get access token and extract the JSON response
             response_token = requests.post(
-                self.environment.auth_url_token,
+                self._environment.auth_url_token,
                 data=data_token,
-                headers=self.environment.headers,
+                headers=self._environment.headers,
             )
             response_json = response_token.json()
 
@@ -307,20 +222,17 @@ class TQ42Client:
         current_datetime = datetime.now()
         file_handling.write_to_file(self._timestamp_file_path, current_datetime)
 
-    def _is_config_filepath_default(self, config_file):
-        return config_file == self.default_config_file
-
     @property
     def _token_file_path(self):
-        return self.token_manager.token_file_path
+        return self._token_manager.token_file_path
 
     @property
     def _timestamp_file_path(self):
-        return self.token_manager.timestamp_file_path
+        return self._token_manager.timestamp_file_path
 
     @property
     def _refresh_token_file_path(self):
-        return self.token_manager.refresh_token_file_path
+        return self._token_manager.refresh_token_file_path
 
     @property
     def metadata(self):
@@ -328,7 +240,7 @@ class TQ42Client:
         :meta private:
         """
 
-        self.token_manager.renew_expring_token()
+        self._token_manager.renew_expiring_token()
         token = misc.get_token(
             service_name="tq42_access_token", backup_save_path=self._token_file_path
         )

--- a/tq42/tests/test_config_environment.py
+++ b/tq42/tests/test_config_environment.py
@@ -75,9 +75,9 @@ class TestConfigEnvironment(unittest.TestCase):
     @mock.patch.dict(
         "os.environ",
         {
-            "TQ42_SDK_BASE_URL": "base_url",
-            "TQ42_SDK_CLIENT_ID": "client_id",
-            "TQ42_SDK_SCOPE": "scope",
+            "TQ42_BASE_URL": "base_url",
+            "TQ42_CLIENT_ID": "client_id",
+            "TQ42_SCOPE": "scope",
         },
     )
     def test_environment_name(self):

--- a/tq42/tests/test_config_environment.py
+++ b/tq42/tests/test_config_environment.py
@@ -1,6 +1,7 @@
 import unittest
+from unittest import mock
 
-from tq42.client import _ConfigEnvironment
+from tq42.utils.environment import ConfigEnvironment
 
 
 class TestConfigEnvironment(unittest.TestCase):
@@ -10,7 +11,7 @@ class TestConfigEnvironment(unittest.TestCase):
     def tearDown(self):
         pass
 
-    def code_data_test(self, env: _ConfigEnvironment):
+    def code_data_test(self, env: ConfigEnvironment):
         expected = {
             "client_id": env.client_id,
             "scope": env.scope,
@@ -23,7 +24,7 @@ class TestConfigEnvironment(unittest.TestCase):
         actual = env.headers
         self.assertEqual(expected, actual)
 
-    def token_data_test(self, env: _ConfigEnvironment):
+    def token_data_test(self, env: ConfigEnvironment):
         expected = {
             "grant_type": "urn:ietf:params:oauth:grant-type:device_code",
             "device_code": "DEVICE CODE",
@@ -33,7 +34,7 @@ class TestConfigEnvironment(unittest.TestCase):
         self.assertEqual(expected, actual)
 
     def test_int_urls(self):
-        env = _ConfigEnvironment(
+        env = ConfigEnvironment(
             "int.terraquantum.io",
             "CLIENT ID",
             "openid profile email",
@@ -52,7 +53,7 @@ class TestConfigEnvironment(unittest.TestCase):
         self.token_data_test(env)
 
     def test_staging_urls(self):
-        env = _ConfigEnvironment(
+        env = ConfigEnvironment(
             "staging.terraquantum.io",
             "CLIENT ID",
             "openid profile email",
@@ -70,3 +71,25 @@ class TestConfigEnvironment(unittest.TestCase):
         )
         self.code_data_test(env)
         self.token_data_test(env)
+
+    @mock.patch.dict(
+        "os.environ",
+        {
+            "TQ42_SDK_BASE_URL": "base_url",
+            "TQ42_SDK_CLIENT_ID": "client_id",
+            "TQ42_SDK_SCOPE": "scope",
+        },
+    )
+    def test_environment_name(self):
+        env = ConfigEnvironment.from_env()
+
+        self.assertEqual("base_url", env.base_url)
+        self.assertEqual("client_id", env.client_id)
+        self.assertEqual("scope", env.scope)
+
+    def test_default_environment(self):
+        env = ConfigEnvironment.from_env()
+
+        self.assertEqual("terraquantum.io", env.base_url)
+        self.assertEqual("gvBa4BHKOTlotDuE6E2HSQBzBDlM00F4", env.client_id)
+        self.assertEqual("openid profile email offline_access tq42", env.scope)

--- a/tq42/utils/environment.py
+++ b/tq42/utils/environment.py
@@ -91,14 +91,11 @@ class ConfigEnvironment:
         }
 
     @staticmethod
-    def from_env(name: Optional[str] = None) -> "ConfigEnvironment":
-        env_var_prefix = "TQ42_SDK_"
-        if name is not None:
-            env_var_prefix = f"{env_var_prefix}{name.upper()}_"
-
-        base_url = os.getenv(f"{env_var_prefix}BASE_URL", _DEFAULT_BASE_URL)
-        client_id = os.getenv(f"{env_var_prefix}CLIENT_ID", _DEFAULT_CLIENT_ID)
-        scope = os.getenv(f"{env_var_prefix}SCOPE", _DEFAULT_SCOPE)
+    def from_env() -> "ConfigEnvironment":
+        env_var_prefix = "TQ42_SDK"
+        base_url = os.getenv(f"{env_var_prefix}_BASE_URL", _DEFAULT_BASE_URL)
+        client_id = os.getenv(f"{env_var_prefix}_CLIENT_ID", _DEFAULT_CLIENT_ID)
+        scope = os.getenv(f"{env_var_prefix}_SCOPE", _DEFAULT_SCOPE)
 
         return ConfigEnvironment(base_url=base_url, client_id=client_id, scope=scope)
 

--- a/tq42/utils/environment.py
+++ b/tq42/utils/environment.py
@@ -92,10 +92,9 @@ class ConfigEnvironment:
 
     @staticmethod
     def from_env() -> "ConfigEnvironment":
-        env_var_prefix = "TQ42_SDK"
-        base_url = os.getenv(f"{env_var_prefix}_BASE_URL", _DEFAULT_BASE_URL)
-        client_id = os.getenv(f"{env_var_prefix}_CLIENT_ID", _DEFAULT_CLIENT_ID)
-        scope = os.getenv(f"{env_var_prefix}_SCOPE", _DEFAULT_SCOPE)
+        base_url = os.getenv("TQ42_BASE_URL", _DEFAULT_BASE_URL)
+        client_id = os.getenv("TQ42_CLIENT_ID", _DEFAULT_CLIENT_ID)
+        scope = os.getenv("TQ42_SCOPE", _DEFAULT_SCOPE)
 
         return ConfigEnvironment(base_url=base_url, client_id=client_id, scope=scope)
 

--- a/tq42/utils/text_files/config.json
+++ b/tq42/utils/text_files/config.json
@@ -1,5 +1,0 @@
-{
-    "base_url": "terraquantum.io",
-    "client_id": "gvBa4BHKOTlotDuE6E2HSQBzBDlM00F4",
-    "scope": "openid profile email offline_access tq42"
-}


### PR DESCRIPTION
This removes the need for multiple / any `config.json` files. To change the environment, just set the following environment variables:

```shell
export TQ42_BASE_URL="..."
export TQ42_CLIENT_ID="..."
export TQ42_SCOPE="...."
```