### PR TITLE
TQ42-1448: fix functional tests for list all projects

### DIFF
--- a/tq42/functional_tests/functional_test_config.py
+++ b/tq42/functional_tests/functional_test_config.py
@@ -1,14 +1,13 @@
 from dataclasses import dataclass
-from typing import Any
 
 from click.testing import CliRunner
 
 from tq42.cli.entrypoint import cli
 from tq42.client import TQ42Client
-from tq42.organization import list_all as list_all_organizations
-from tq42.project import list_all as list_all_projects
 from tq42.experiment import list_all as list_all_experiments
 from tq42.experiment_run import list_all as list_all_experiment_runs
+from tq42.organization import list_all as list_all_organizations
+from tq42.project import list_all as list_all_projects
 
 
 @dataclass()
@@ -18,7 +17,6 @@ class Args:
     exp: str
     run: str
     export_path: str
-    config: Any
 
 
 class FunctionalTestConfig:
@@ -45,20 +43,16 @@ class FunctionalTestConfig:
     def export_path(self):
         return self.args.export_path
 
-    @property
-    def config(self):
-        return self.args.config
-
     def get_client(self) -> TQ42Client:
         if self._client is None:
-            self._client = TQ42Client(self.config)
+            self._client = TQ42Client()
         return self._client
 
     @staticmethod
     def prepare_defaults():
         auto_pick = False
         client = TQ42Client()
-        arguments = Args(org="", proj="", exp="", run="", export_path="", config=None)
+        arguments = Args(org="", proj="", exp="", run="", export_path="")
 
         choices = [
             "{} ({})".format(org.id, org.data.name)

--- a/tq42/functional_tests/test_functional_tq42_api.py
+++ b/tq42/functional_tests/test_functional_tq42_api.py
@@ -1,6 +1,8 @@
 import unittest
 import uuid
+from uuid import uuid4
 
+from tq42.exceptions import PermissionDeniedError
 from tq42.organization import list_all as list_all_organizations, Organization
 from tq42.project import Project, list_all as list_all_projects
 from tq42.experiment import Experiment, list_all as list_all_experiments
@@ -51,6 +53,10 @@ class TestFunctionalTQ42API(unittest.TestCase, FunctionalTestConfig):
         # Expect that specific project is in project list
         proj_ids = [proj.id for proj in proj_list]
         self.assertIn(self.proj, proj_ids)
+
+    def test_proj_list_with_invalid_org_id(self):
+        with self.assertRaises(PermissionDeniedError):
+            list_all_projects(client=self.get_client(), organization_id=str(uuid4()))
 
     def test_proj_get(self):
         proj = Project(client=self.get_client(), id=self.proj)


### PR DESCRIPTION
This now only fixes the functional tests to also test that `list_all` throws an exception if the passed id is invalid.